### PR TITLE
Add support for xcode 7.1+ (osx 10.11)

### DIFF
--- a/third_party/Makefile-common
+++ b/third_party/Makefile-common
@@ -486,7 +486,12 @@ built-sparkle-prepare:
 	@echo "THIRD_PARTY: Patching Sparkle.framework..."
 	if [ -d $(PATCHES_DIR)/sparkle ]; then \
 		cd "$(SPARKLE_BUILD_DIR)"; \
-		for patch_file in `ls $(PATCHES_DIR)/sparkle/*.diff`; do \
+		if [ $(XCODE_VERSION_MAJOR) -ge 0700 ] ; then \
+			patches="`ls $(PATCHES_DIR)/sparkle/*.diff`" ; \
+		else \
+			patches="`ls $(PATCHES_DIR)/sparkle/[0-9][0-9]*.diff`" ; \
+		fi ; \
+		for patch_file in $${patches}; do \
 			patch_name="$$(basename "$${patch_file}")" ; \
 			patch -p1 -N --dry-run -i $$patch_file > /dev/null; \
 			if [ $$? == 0 ]; then \
@@ -500,6 +505,9 @@ built-sparkle-prepare:
 				echo "error: Sparkle patch could not be applied: $(SPARKLE_NAME)/$${patch_name}" ; \
 			fi \
 		done; \
+		sed -i '' -e "s|@OPENSSL_STAGING_DIR@|$(OPENSSL_STAGING_DIR)|g" \
+			  -e "s|@TARGET_ARCH@|$(CURRENT_ARCH)|g" \
+			     "$(SPARKLE_BUILD_DIR)/Extras/Source Code/Sparkle.xcodeproj/project.pbxproj" ; \
 		cp -f -p -X "$(PATCHES_DIR)/sparkle/de.lproj/Sparkle.strings" "Extras/Source Code/de.lproj/Sparkle.strings" ; \
 		cp -f -p -X "$(PATCHES_DIR)/sparkle/it.lproj/Sparkle.strings" "Extras/Source Code/it.lproj/Sparkle.strings" ; \
 		cp -f -p -X "$(PATCHES_DIR)/sparkle/ru.lproj/Sparkle.strings" "Extras/Source Code/ru.lproj/Sparkle.strings" ; \

--- a/third_party/sources/patches/sparkle/add-default-includes-and-libs.diff
+++ b/third_party/sources/patches/sparkle/add-default-includes-and-libs.diff
@@ -1,0 +1,42 @@
+--- a/Extras/Source Code/Sparkle.xcodeproj/project.pbxproj	2008-09-13 20:55:00.000000000 -0700
++++ b/Extras/Source Code/Sparkle.xcodeproj/project.pbxproj	2015-11-18 17:00:30.000000000 -0800
+@@ -976,6 +983,12 @@
+ 			isa = XCBuildConfiguration;
+ 			baseConfigurationReference = FA1941CA0D94A70100DD942E /* ConfigFrameworkDebug.xcconfig */;
+ 			buildSettings = {
++				HEADER_SEARCH_PATHS = "@OPENSSL_STAGING_DIR@/include/@TARGET_ARCH@";
++				LIBRARY_SEARCH_PATHS = "@OPENSSL_STAGING_DIR@/lib";
++				OTHER_LDFLAGS = (
++					"-lcrypto",
++					"-lz",
++				);
+ 			};
+ 			name = Debug;
+ 		};
+@@ -984,6 +997,12 @@
+ 			baseConfigurationReference = FA1941D50D94A70100DD942E /* ConfigFrameworkRelease.xcconfig */;
+ 			buildSettings = {
+ 				GCC_DEBUGGING_SYMBOLS = full;
++				HEADER_SEARCH_PATHS = "@OPENSSL_STAGING_DIR@/include/@TARGET_ARCH@";
++				LIBRARY_SEARCH_PATHS = "@OPENSSL_STAGING_DIR@/lib";
++				OTHER_LDFLAGS = (
++					"-lcrypto",
++					"-lz",
++				);
+ 			};
+ 			name = Release;
+ 		};
+@@ -1013,7 +1032,13 @@
+ 			isa = XCBuildConfiguration;
+ 			baseConfigurationReference = 61072EB20DF2640C008FE88B /* ConfigFrameworkReleaseGCSupport.xcconfig */;
+ 			buildSettings = {
++				HEADER_SEARCH_PATHS = "@OPENSSL_STAGING_DIR@/include/@TARGET_ARCH@";
+ 				INSTALL_PATH = "@loader_path/../Frameworks";
++				LIBRARY_SEARCH_PATHS = "@OPENSSL_STAGING_DIR@/lib";
++				OTHER_LDFLAGS = (
++					"-lcrypto",
++					"-lz",
++				);
+ 			};
+ 			name = "Release (GC dual-mode; 10.5-only)";
+ 		};


### PR DESCRIPTION
I originally wanted to add support for openvpn git version, but I ran across this issue building tunnelblick on OSX 10.11 (I see now that openvpn git version has been added :+1: )

This fixes #277 

The changes work like this
 - Openvpn is built before sparkle, this is so that openssl can be built and statically linked in sparkle.
 - ~~Headers from the openssl build are symlinked to the sparkle source directory~~
 - ~~The headers are then updated to reflect this in the SUDSAVerifier.m file~~
 - A patch is used to adjust the sparkle xcode project to include the built openssl headers and libs, this is then dynamically adjusted depending on your machine. This patch also links sparkle against libcrypto and libz.

~~There were some whitespace issues (because of using tabs) and this was problematic while using atom editor. I can get rid of this if you desire.~~

Using this I get a working build on my 10.11 system. I'd like to know if this works on your system and older versions of xcode.

Let me know if you want me to make any changes or feel free to pick the commits directly and edit them to your desire.

~~EDIT: I may have spoke too soon. TunnelBlick runs but whenever I try to add an ovpn file I get this~~
>An error (status 190) ocurred while trying to check the security of the lukas-macbook configuration. Please quit and relaunch Tunnelblick. If the problem persists, please reinstall Tunnelblick

~~Not sure if this is just a problem with master or a problem with this PR, I will have to build a vanilla master build to test. Here is a log, http://pastebin.com/raw.php?i=xtq7ERjr~~

~~Seems to be an issue here,~~ 
```
2015-11-18 23:51:46 Tunnelblick[32615] tunnelblickd status from compareShadowCopy: 190
                                       tunnelblickd stderr:
                                       'Must be a directory: /Users/lukas/Library/Application Support/Tunnelblick/Configurations/lukas-macbook.tblk'
2015-11-18 23:51:46 Tunnelblick[32615] Internal Tunnelblick error: unknown status 190 from compareShadowCopy(lukas-macbook)
2015-11-18 23:51:57 Tunnelblick[32615] An uncaught exception was raised
2015-11-18 23:51:57 Tunnelblick[32615] must provide a launch path
```
So it looks like it doesn't have to do with this PR

### Update:

I have updated this PR, the symlinking and stuff is absolutely not needed when using the openssl include and lib dirs in the sparkle patch I created. It is much more simple now and produces a working build for me. The original PR commit can be seen here, https://github.com/lrusak/Tunnelblick/commit/f7aa72d4038c08a65131a35d8f5269b661f7848d