### PR TITLE
Ignore 'Auth-Token' messages from server.

### DIFF
--- a/tunnelblick/VPNConnection.m
+++ b/tunnelblick/VPNConnection.m
@@ -2742,7 +2742,9 @@ static pthread_mutex_t lastStateMutex = PTHREAD_MUTEX_INITIALIZER;
                 [timer tbSetTolerance: -1.0];
             } else {
 				TBLog(@"DB-AU", @"processLine: PASSWORD request from server");
-                if (  authFailed  ) {
+                if ([parameterString hasPrefix:@"Auth-Token:"]) {
+                    TBLog(@"DB-AU", @"processLine: Ignoring Auth-Token from server");
+                } else if (  authFailed  ) {
                     if (  userWantsState == userWantsUndecided  ) {
                         // We don't know what to do yet: repeat this again later
 						TBLog(@"DB-AU", @"processLine: authFailed and userWantsUndecided, queuing credentialsHaveBeenAskedForHandler for execution in 0.5 seconds");


### PR DESCRIPTION
Sometimes the server sends 'Auth-Token' messages in the form:
'>PASSWORD:Auth-Token:xxxxxxxxxxxxxxxxxx' (Especially when
dealing with Challenge/Response mechanisms).

The current implementation mistakes these messages with a more
classical '>PASSWORD:Need 'Auth' username/password' message,
thus sends again username and password.
This is detected by the servers, which warns us that those
credentials were unexpected at that time.

While there is no harm sending unexpected credentials, I feel
it's more clean to handle (and ignore) those messages.

[Implementation is in OpenVPN](https://github.com/OpenVPN/openvpn/blob/master/src/openvpn/manage.c#L2716-L2720)