### PR TITLE
keychain management client support for openvpn >= 2.4.0

### DIFF
--- a/tunnelblick/Tunnelblick.xcodeproj/project.pbxproj
+++ b/tunnelblick/Tunnelblick.xcodeproj/project.pbxproj
@@ -241,6 +241,11 @@
 		B8C9FB49170C77A400BCA243 /* LeftNavViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B8C9FB46170C77A400BCA243 /* LeftNavViewController.m */; };
 		B8D807031832EEC400A0B937 /* NSTimer+TB.m in Sources */ = {isa = PBXBuildFile; fileRef = B8D807021832EEC400A0B937 /* NSTimer+TB.m */; };
 		B8F6264C1641C8C700943C59 /* easyRsa.m in Sources */ = {isa = PBXBuildFile; fileRef = B8F6264B1641C8C700943C59 /* easyRsa.m */; };
+		C09E285C1EAE86C700F07A74 /* base64.c in Sources */ = {isa = PBXBuildFile; fileRef = C09E28521EAE86C700F07A74 /* base64.c */; };
+		C09E285D1EAE86C700F07A74 /* cert_data.c in Sources */ = {isa = PBXBuildFile; fileRef = C09E28541EAE86C700F07A74 /* cert_data.c */; };
+		C09E285E1EAE86C700F07A74 /* common_osx.c in Sources */ = {isa = PBXBuildFile; fileRef = C09E28561EAE86C700F07A74 /* common_osx.c */; };
+		C09E285F1EAE86C700F07A74 /* crypto_osx.c in Sources */ = {isa = PBXBuildFile; fileRef = C09E28581EAE86C700F07A74 /* crypto_osx.c */; };
+		C09E28601EAE86C700F07A74 /* keychain_mcd.c in Sources */ = {isa = PBXBuildFile; fileRef = C09E285A1EAE86C700F07A74 /* keychain_mcd.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -638,6 +643,16 @@
 		B8D807021832EEC400A0B937 /* NSTimer+TB.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSTimer+TB.m"; sourceTree = "<group>"; };
 		B8F6264A1641C8C700943C59 /* easyRsa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = easyRsa.h; sourceTree = "<group>"; };
 		B8F6264B1641C8C700943C59 /* easyRsa.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; fileEncoding = 4; path = easyRsa.m; sourceTree = "<group>"; };
+		C09E28521EAE86C700F07A74 /* base64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = base64.c; sourceTree = "<group>"; };
+		C09E28531EAE86C700F07A74 /* base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = base64.h; sourceTree = "<group>"; };
+		C09E28541EAE86C700F07A74 /* cert_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cert_data.c; sourceTree = "<group>"; };
+		C09E28551EAE86C700F07A74 /* cert_data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cert_data.h; sourceTree = "<group>"; };
+		C09E28561EAE86C700F07A74 /* common_osx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = common_osx.c; sourceTree = "<group>"; };
+		C09E28571EAE86C700F07A74 /* common_osx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_osx.h; sourceTree = "<group>"; };
+		C09E28581EAE86C700F07A74 /* crypto_osx.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crypto_osx.c; sourceTree = "<group>"; };
+		C09E28591EAE86C700F07A74 /* crypto_osx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crypto_osx.h; sourceTree = "<group>"; };
+		C09E285A1EAE86C700F07A74 /* keychain_mcd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = keychain_mcd.c; sourceTree = "<group>"; };
+		C09E285B1EAE86C700F07A74 /* keychain_mcd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = keychain_mcd.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -728,6 +743,7 @@
 		080E96DDFE201D6D7F000001 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				C09E28511EAE869A00F07A74 /* Keychain-mcd */,
 				B8407882170CE4E10002B941 /* Authorization & Keychain */,
 				B840787F170CE4130002B941 /* Common */,
 				B8407881170CE4B00002B941 /* Class Extensions & Subclasses */,
@@ -1333,6 +1349,23 @@
 			name = Uninstaller;
 			sourceTree = "<group>";
 		};
+		C09E28511EAE869A00F07A74 /* Keychain-mcd */ = {
+			isa = PBXGroup;
+			children = (
+				C09E28521EAE86C700F07A74 /* base64.c */,
+				C09E28531EAE86C700F07A74 /* base64.h */,
+				C09E28541EAE86C700F07A74 /* cert_data.c */,
+				C09E28551EAE86C700F07A74 /* cert_data.h */,
+				C09E28561EAE86C700F07A74 /* common_osx.c */,
+				C09E28571EAE86C700F07A74 /* common_osx.h */,
+				C09E28581EAE86C700F07A74 /* crypto_osx.c */,
+				C09E28591EAE86C700F07A74 /* crypto_osx.h */,
+				C09E285A1EAE86C700F07A74 /* keychain_mcd.c */,
+				C09E285B1EAE86C700F07A74 /* keychain_mcd.h */,
+			);
+			name = "Keychain-mcd";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXLegacyTarget section */
@@ -1793,6 +1826,7 @@
 				633DF4591312B13100B8606C /* ConfigurationManager.m in Sources */,
 				639A1100132AC9D800754C2A /* StatusWindowController.m in Sources */,
 				63ABFE9C1349E435003DEB64 /* LoginWindowController.m in Sources */,
+				C09E285C1EAE86C700F07A74 /* base64.c in Sources */,
 				6388563E134B7E1C008DF8C1 /* PassphraseWindowController.m in Sources */,
 				635ECCF51378885600F67F8D /* DBPrefsWindowController.m in Sources */,
 				635ECCFA137888A800F67F8D /* MyPrefsWindowController.m in Sources */,
@@ -1800,14 +1834,18 @@
 				635ECE631378EA4000F67F8D /* AppearanceView.m in Sources */,
 				635ECE6C1378EA7000F67F8D /* InfoView.m in Sources */,
 				63E56EE713848338007E39AB /* VPNService.m in Sources */,
+				C09E28601EAE86C700F07A74 /* keychain_mcd.c in Sources */,
 				63E56EE813848338007E39AB /* VPNServiceCreateAccountController.m in Sources */,
 				63E56EE913848338007E39AB /* VPNServiceIntroController.m in Sources */,
 				63E56EEA13848338007E39AB /* VPNServiceLoginController.m in Sources */,
 				63E56EEB13848338007E39AB /* VPNServiceProveController.m in Sources */,
+				C09E285D1EAE86C700F07A74 /* cert_data.c in Sources */,
 				63E56EEC13848338007E39AB /* VPNServiceSorryController.m in Sources */,
 				63E56EED13848338007E39AB /* VPNServiceTermsOfServiceController.m in Sources */,
 				63E56EEE13848338007E39AB /* VPNServiceWelcomeController.m in Sources */,
+				C09E285F1EAE86C700F07A74 /* crypto_osx.c in Sources */,
 				634F1B9D1D23FD9D00B1E929 /* Tracker.m in Sources */,
+				C09E285E1EAE86C700F07A74 /* common_osx.c in Sources */,
 				6375FB481387F0270034CB78 /* SettingsSheetWindowController.m in Sources */,
 				635971421C06736B0055FBC5 /* UIHelper.m in Sources */,
 				634DC4B0139F9BC600403DD3 /* ConfigurationsView.m in Sources */,

--- a/tunnelblick/VPNConnection.h
+++ b/tunnelblick/VPNConnection.h
@@ -142,6 +142,7 @@ struct Statistics {
 	BOOL volatile	connectAfterDisconnect; // True if need to connect again after the disconnect completes
 	BOOL volatile	connectAfterDisconnectUserKnows; // Argument for the reconnect
     BOOL volatile   completelyDisconnected; // True only after GUI has caught up to disconnect request
+    SecIdentityRef  identityRef;         // Identity reference for keychain support
 }
 
 // PUBLIC METHODS:

--- a/tunnelblick/base64.c
+++ b/tunnelblick/base64.c
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 1995-2001 Kungliga Tekniska Högskolan
+ * (Royal Institute of Technology, Stockholm, Sweden).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#elif defined(_MSC_VER)
+#include "config-msvc.h"
+#endif
+
+#include "syshead.h"
+
+#include "base64.h"
+
+#include "memdbg.h"
+
+static char base64_chars[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+/*
+ * base64 encode input data of length size to malloced
+ * buffer which is returned as *str.  Returns string
+ * length of *str.
+ */
+int
+openvpn_base64_encode(const void *data, int size, char **str)
+{
+    char *s, *p;
+    int i;
+    int c;
+    const unsigned char *q;
+
+    if (size < 0)
+    {
+        return -1;
+    }
+    p = s = (char *) malloc(size * 4 / 3 + 4);
+    if (p == NULL)
+    {
+        return -1;
+    }
+    q = (const unsigned char *) data;
+    i = 0;
+    for (i = 0; i < size; )
+    {
+        c = q[i++];
+        c *= 256;
+        if (i < size)
+        {
+            c += q[i];
+        }
+        i++;
+        c *= 256;
+        if (i < size)
+        {
+            c += q[i];
+        }
+        i++;
+        p[0] = base64_chars[(c & 0x00fc0000) >> 18];
+        p[1] = base64_chars[(c & 0x0003f000) >> 12];
+        p[2] = base64_chars[(c & 0x00000fc0) >> 6];
+        p[3] = base64_chars[(c & 0x0000003f) >> 0];
+        if (i > size)
+        {
+            p[3] = '=';
+        }
+        if (i > size + 1)
+        {
+            p[2] = '=';
+        }
+        p += 4;
+    }
+    *p = 0;
+    *str = s;
+    return strlen(s);
+}
+
+static int
+pos(char c)
+{
+    char *p;
+    for (p = base64_chars; *p; p++)
+    {
+        if (*p == c)
+        {
+            return p - base64_chars;
+        }
+    }
+    return -1;
+}
+
+#define DECODE_ERROR 0xffffffff
+
+static unsigned int
+token_decode(const char *token)
+{
+    int i;
+    unsigned int val = 0;
+    int marker = 0;
+    if (!token[0] || !token[1] || !token[2] || !token[3])
+    {
+        return DECODE_ERROR;
+    }
+    for (i = 0; i < 4; i++)
+    {
+        val *= 64;
+        if (token[i] == '=')
+        {
+            marker++;
+        }
+        else if (marker > 0)
+        {
+            return DECODE_ERROR;
+        }
+        else
+        {
+            val += pos(token[i]);
+        }
+    }
+    if (marker > 2)
+    {
+        return DECODE_ERROR;
+    }
+    return (marker << 24) | val;
+}
+/*
+ * Decode base64 str, outputting data to buffer
+ * at data of length size.  Return length of
+ * decoded data written or -1 on error or overflow.
+ */
+int
+openvpn_base64_decode(const char *str, void *data, int size)
+{
+    const char *p;
+    unsigned char *q;
+    unsigned char *e = NULL;
+
+    q = data;
+    if (size >= 0)
+    {
+        e = q + size;
+    }
+    for (p = str; *p && (*p == '=' || strchr(base64_chars, *p)); p += 4)
+    {
+        unsigned int val = token_decode(p);
+        unsigned int marker = (val >> 24) & 0xff;
+        if (val == DECODE_ERROR)
+        {
+            return -1;
+        }
+        if (e && q >= e)
+        {
+            return -1;
+        }
+        *q++ = (val >> 16) & 0xff;
+        if (marker < 2)
+        {
+            if (e && q >= e)
+            {
+                return -1;
+            }
+            *q++ = (val >> 8) & 0xff;
+        }
+        if (marker < 1)
+        {
+            if (e && q >= e)
+            {
+                return -1;
+            }
+            *q++ = val & 0xff;
+        }
+    }
+    return q - (unsigned char *) data;
+}

--- a/tunnelblick/base64.c
+++ b/tunnelblick/base64.c
@@ -1,4 +1,25 @@
 /*
+ *  Modifications copyright 2017 Pavel Kondratiev <kaloprominat@yandex.ru>
+ *  All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  or see http://www.gnu.org/licenses/.
+ */
+/*
  * Copyright (c) 1995-2001 Kungliga Tekniska Högskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.

--- a/tunnelblick/base64.c
+++ b/tunnelblick/base64.c
@@ -52,17 +52,11 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#elif defined(_MSC_VER)
-#include "config-msvc.h"
-#endif
-
-#include "syshead.h"
-
 #include "base64.h"
 
-#include "memdbg.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 static char base64_chars[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -72,10 +66,9 @@ static char base64_chars[] =
  * length of *str.
  */
 int
-openvpn_base64_encode(const void *data, int size, char **str)
+base64_encode(const void *data, int size, char **str)
 {
     char *s, *p;
-    int i;
     int c;
     const unsigned char *q;
 
@@ -89,7 +82,7 @@ openvpn_base64_encode(const void *data, int size, char **str)
         return -1;
     }
     q = (const unsigned char *) data;
-    i = 0;
+    int i = 0;
     for (i = 0; i < size; )
     {
         c = q[i++];
@@ -178,7 +171,7 @@ token_decode(const char *token)
  * decoded data written or -1 on error or overflow.
  */
 int
-openvpn_base64_decode(const char *str, void *data, int size)
+base64_decode(const char *str, void *data, int size)
 {
     const char *p;
     unsigned char *q;

--- a/tunnelblick/base64.h
+++ b/tunnelblick/base64.h
@@ -55,8 +55,8 @@
 #ifndef _BASE64_H_
 #define _BASE64_H_
 
-int openvpn_base64_encode(const void *data, int size, char **str);
+int base64_encode(const void *data, int size, char **str);
 
-int openvpn_base64_decode(const char *str, void *data, int size);
+int base64_decode(const char *str, void *data, int size);
 
 #endif

--- a/tunnelblick/base64.h
+++ b/tunnelblick/base64.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 1995, 1996, 1997 Kungliga Tekniska Högskolan
+ * (Royal Institute of Technology, Stockholm, Sweden).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _BASE64_H_
+#define _BASE64_H_
+
+int openvpn_base64_encode(const void *data, int size, char **str);
+
+int openvpn_base64_decode(const char *str, void *data, int size);
+
+#endif

--- a/tunnelblick/base64.h
+++ b/tunnelblick/base64.h
@@ -1,4 +1,25 @@
 /*
+ *  Modifications copyright 2017 Pavel Kondratiev <kaloprominat@yandex.ru>
+ *  All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  or see http://www.gnu.org/licenses/.
+ */
+/*
  * Copyright (c) 1995, 1996, 1997 Kungliga Tekniska Högskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.

--- a/tunnelblick/cert_data.c
+++ b/tunnelblick/cert_data.c
@@ -1,0 +1,867 @@
+/*
+ *  OpenVPN -- An application to securely tunnel IP networks
+ *             over a single UDP port, with support for SSL/TLS-based
+ *             session authentication and key exchange,
+ *             packet encryption, packet authentication, and
+ *             packet compression.
+ *
+ *  Copyright (C) 2010 Brian Raderman <brian@irregularexpression.org>
+ *  Copyright (C) 2013-2015 Vasily Kulikov <segoon@openwall.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+
+#include "cert_data.h"
+#include <CommonCrypto/CommonDigest.h>
+#include <openssl/ssl.h>
+
+#include "common_osx.h"
+#include "crypto_osx.h"
+#include <err.h>
+
+CFStringRef kCertDataSubjectName = CFSTR("subject"),
+            kCertDataIssuerName = CFSTR("issuer"),
+            kCertDataSha1Name = CFSTR("SHA1"),
+            kCertDataMd5Name = CFSTR("MD5"),
+            kCertDataSerialName = CFSTR("serial"),
+            kCertNameFwdSlash = CFSTR("/"),
+            kCertNameEquals = CFSTR("=");
+CFStringRef kCertNameOrganization = CFSTR("o"),
+            kCertNameOrganizationalUnit = CFSTR("ou"),
+            kCertNameCountry = CFSTR("c"),
+            kCertNameLocality = CFSTR("l"),
+            kCertNameState = CFSTR("st"),
+            kCertNameCommonName = CFSTR("cn"),
+            kCertNameEmail = CFSTR("e");
+CFStringRef kStringSpace = CFSTR(" "),
+            kStringEmpty = CFSTR("");
+
+typedef struct _CertName
+{
+    CFArrayRef countryName, organization, organizationalUnit, commonName, description, emailAddress,
+               stateName, localityName;
+} CertName, *CertNameRef;
+
+typedef struct _DescData
+{
+    CFStringRef name, value;
+} DescData, *DescDataRef;
+
+void destroyDescData(DescDataRef pData);
+
+CertNameRef
+createCertName()
+{
+    CertNameRef pCertName = (CertNameRef)malloc(sizeof(CertName));
+    pCertName->countryName = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->organization =  CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->organizationalUnit = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->commonName = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->description = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->emailAddress = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->stateName = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->localityName = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    return pCertName;
+}
+
+void
+destroyCertName(CertNameRef pCertName)
+{
+    if (!pCertName)
+    {
+        return;
+    }
+
+    CFRelease(pCertName->countryName);
+    CFRelease(pCertName->organization);
+    CFRelease(pCertName->organizationalUnit);
+    CFRelease(pCertName->commonName);
+    CFRelease(pCertName->description);
+    CFRelease(pCertName->emailAddress);
+    CFRelease(pCertName->stateName);
+    CFRelease(pCertName->localityName);
+    free(pCertName);
+}
+
+bool
+CFStringRefCmpCString(CFStringRef cfstr, const char *str)
+{
+    CFStringRef tmp = CFStringCreateWithCStringNoCopy(NULL, str, kCFStringEncodingUTF8, kCFAllocatorNull);
+    CFComparisonResult cresult = CFStringCompare(cfstr, tmp, 0);
+    bool result = cresult == kCFCompareEqualTo;
+    CFRelease(tmp);
+    return result;
+}
+
+CFDateRef
+GetDateFieldFromCertificate(SecCertificateRef certificate, CFTypeRef oid)
+{
+    const void *keys[] = { oid };
+    CFDictionaryRef dict = NULL;
+    CFErrorRef error;
+    CFDateRef date = NULL;
+
+    CFArrayRef keySelection = CFArrayCreate(NULL, keys, sizeof(keys)/sizeof(keys[0]), &kCFTypeArrayCallBacks);
+    dict = SecCertificateCopyValues(certificate, keySelection, &error);
+    if (dict == NULL)
+    {
+        printErrorMsg("GetDateFieldFromCertificate: SecCertificateCopyValues", error);
+        goto release_ks;
+    }
+    CFDictionaryRef vals = dict ? CFDictionaryGetValue(dict, oid) : NULL;
+    CFNumberRef vals2 = vals ? CFDictionaryGetValue(vals, kSecPropertyKeyValue) : NULL;
+    if (vals2 == NULL)
+    {
+        goto release_dict;
+    }
+
+    CFAbsoluteTime validityNotBefore;
+    if (CFNumberGetValue(vals2, kCFNumberDoubleType, &validityNotBefore))
+    {
+        date = CFDateCreate(kCFAllocatorDefault,validityNotBefore);
+    }
+
+release_dict:
+    CFRelease(dict);
+release_ks:
+    CFRelease(keySelection);
+    return date;
+}
+
+CFArrayRef
+GetFieldsFromCertificate(SecCertificateRef certificate, CFTypeRef oid)
+{
+    CFMutableArrayRef fields = CFArrayCreateMutable(NULL, 0, NULL);
+    CertNameRef pCertName = createCertName();
+    const void *keys[] = { oid, };
+    CFDictionaryRef dict;
+    CFErrorRef error;
+
+    CFArrayRef keySelection = CFArrayCreate(NULL, keys, 1, NULL);
+
+    dict = SecCertificateCopyValues(certificate, keySelection, &error);
+    if (dict == NULL)
+    {
+        printErrorMsg("GetFieldsFromCertificate: SecCertificateCopyValues", error);
+        CFRelease(keySelection);
+        CFRelease(fields);
+        destroyCertName(pCertName);
+        return NULL;
+    }
+    CFDictionaryRef vals = CFDictionaryGetValue(dict, oid);
+    CFArrayRef vals2 = vals ? CFDictionaryGetValue(vals, kSecPropertyKeyValue) : NULL;
+    if (vals2)
+    {
+        for (int i = 0; i < CFArrayGetCount(vals2); i++) {
+            CFDictionaryRef subDict = CFArrayGetValueAtIndex(vals2, i);
+            CFStringRef label = CFDictionaryGetValue(subDict, kSecPropertyKeyLabel);
+            CFStringRef value = CFDictionaryGetValue(subDict, kSecPropertyKeyValue);
+
+            if (CFStringCompare(label, kSecOIDEmailAddress, 0) == kCFCompareEqualTo)
+            {
+                CFArrayAppendValue((CFMutableArrayRef)pCertName->emailAddress, value);
+            }
+            else if (CFStringCompare(label, kSecOIDCountryName, 0) == kCFCompareEqualTo)
+            {
+                CFArrayAppendValue((CFMutableArrayRef)pCertName->countryName, value);
+            }
+            else if (CFStringCompare(label, kSecOIDOrganizationName, 0) == kCFCompareEqualTo)
+            {
+                CFArrayAppendValue((CFMutableArrayRef)pCertName->organization, value);
+            }
+            else if (CFStringCompare(label, kSecOIDOrganizationalUnitName, 0) == kCFCompareEqualTo)
+            {
+                CFArrayAppendValue((CFMutableArrayRef)pCertName->organizationalUnit, value);
+            }
+            else if (CFStringCompare(label, kSecOIDCommonName, 0) == kCFCompareEqualTo)
+            {
+                CFArrayAppendValue((CFMutableArrayRef)pCertName->commonName, value);
+            }
+            else if (CFStringCompare(label, kSecOIDDescription, 0) == kCFCompareEqualTo)
+            {
+                CFArrayAppendValue((CFMutableArrayRef)pCertName->description, value);
+            }
+            else if (CFStringCompare(label, kSecOIDStateProvinceName, 0) == kCFCompareEqualTo)
+            {
+                CFArrayAppendValue((CFMutableArrayRef)pCertName->stateName, value);
+            }
+            else if (CFStringCompare(label, kSecOIDLocalityName, 0) == kCFCompareEqualTo)
+            {
+                CFArrayAppendValue((CFMutableArrayRef)pCertName->localityName, value);
+            }
+        }
+        CFArrayAppendValue(fields, pCertName);
+    }
+
+    CFRelease(dict);
+    CFRelease(keySelection);
+    return fields;
+}
+
+CertDataRef
+createCertDataFromCertificate(SecCertificateRef certificate)
+{
+    CertDataRef pCertData = (CertDataRef)malloc(sizeof(CertData));
+    pCertData->subject = GetFieldsFromCertificate(certificate, kSecOIDX509V1SubjectName);
+    pCertData->issuer = GetFieldsFromCertificate(certificate, kSecOIDX509V1IssuerName);
+
+    CFDataRef data = SecCertificateCopyData(certificate);
+    if (data == NULL)
+    {
+        warnx("SecCertificateCopyData() returned NULL");
+        destroyCertData(pCertData);
+        return NULL;
+    }
+
+    unsigned char sha1[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1(CFDataGetBytePtr(data), CFDataGetLength(data), sha1);
+    pCertData->sha1 = createHexString(sha1, CC_SHA1_DIGEST_LENGTH);
+
+    unsigned char md5[CC_MD5_DIGEST_LENGTH];
+    CC_MD5(CFDataGetBytePtr(data), CFDataGetLength(data), md5);
+    pCertData->md5 = createHexString((unsigned char *)md5, CC_MD5_DIGEST_LENGTH);
+
+    CFDataRef serial = SecCertificateCopySerialNumber(certificate, NULL);
+    pCertData->serial = createHexString((unsigned char *)CFDataGetBytePtr(serial), CFDataGetLength(serial));
+    CFRelease(serial);
+
+    return pCertData;
+}
+
+CFStringRef
+stringFromRange(const char *cstring, CFRange range)
+{
+    CFStringRef str = CFStringCreateWithBytes(NULL, (uint8 *)&cstring[range.location], range.length, kCFStringEncodingUTF8, false);
+    CFMutableStringRef mutableStr = CFStringCreateMutableCopy(NULL, 0, str);
+    CFStringTrimWhitespace(mutableStr);
+    CFRelease(str);
+    return mutableStr;
+}
+
+DescDataRef
+createDescData(const char *description, CFRange nameRange, CFRange valueRange)
+{
+    DescDataRef pRetVal = (DescDataRef)malloc(sizeof(DescData));
+
+    memset(pRetVal, 0, sizeof(DescData));
+
+    if (nameRange.length > 0)
+    {
+        pRetVal->name = stringFromRange(description, nameRange);
+    }
+
+    if (valueRange.length > 0)
+    {
+        pRetVal->value = stringFromRange(description, valueRange);
+    }
+
+#if 0
+    fprintf(stderr, "name = '%s', value = '%s'\n",
+            CFStringGetCStringPtr(pRetVal->name, kCFStringEncodingUTF8),
+            CFStringGetCStringPtr(pRetVal->value, kCFStringEncodingUTF8));
+#endif
+    return pRetVal;
+}
+
+void
+destroyDescData(DescDataRef pData)
+{
+    if (pData->name)
+    {
+        CFRelease(pData->name);
+    }
+
+    if (pData->value)
+    {
+        CFRelease(pData->value);
+    }
+
+    free(pData);
+}
+
+CFArrayRef
+createDescDataPairs(const char *description)
+{
+    int numChars = strlen(description);
+    CFRange nameRange, valueRange;
+    DescDataRef pData;
+    CFMutableArrayRef retVal = CFArrayCreateMutable(NULL, 0, NULL);
+
+    int i = 0;
+
+    nameRange = CFRangeMake(0, 0);
+    valueRange = CFRangeMake(0, 0);
+    bool bInValue = false;
+
+    while (i < numChars)
+    {
+        if (!bInValue && (description[i] != ':'))
+        {
+            nameRange.length++;
+        }
+        else if (bInValue && (description[i] != ':'))
+        {
+            valueRange.length++;
+        }
+        else if (!bInValue)
+        {
+            bInValue = true;
+            valueRange.location = i + 1;
+            valueRange.length = 0;
+        }
+        else /*(bInValue) */
+        {
+            bInValue = false;
+            while (description[i] != ' ')
+            {
+                valueRange.length--;
+                i--;
+            }
+
+            pData = createDescData(description, nameRange, valueRange);
+            CFArrayAppendValue(retVal, pData);
+
+            nameRange.location = i + 1;
+            nameRange.length = 0;
+        }
+
+        i++;
+    }
+
+    pData = createDescData(description, nameRange, valueRange);
+    CFArrayAppendValue(retVal, pData);
+    return retVal;
+}
+
+void
+arrayDestroyDescData(const void *val, void *context)
+{
+    DescDataRef pData = (DescDataRef) val;
+    destroyDescData(pData);
+}
+
+
+int
+parseNameComponent(CFStringRef dn, CFStringRef *pName, CFStringRef *pValue)
+{
+    CFArrayRef nameStrings = CFStringCreateArrayBySeparatingStrings(NULL, dn, kCertNameEquals);
+
+    *pName = *pValue = NULL;
+
+    if (CFArrayGetCount(nameStrings) != 2)
+    {
+        return 0;
+    }
+
+    CFMutableStringRef str;
+
+    str = CFStringCreateMutableCopy(NULL, 0, CFArrayGetValueAtIndex(nameStrings, 0));
+    CFStringTrimWhitespace(str);
+    *pName = str;
+
+    str = CFStringCreateMutableCopy(NULL, 0, CFArrayGetValueAtIndex(nameStrings, 1));
+    CFStringTrimWhitespace(str);
+    *pValue = str;
+
+    CFRelease(nameStrings);
+    return 1;
+}
+
+int
+tryAppendSingleCertField(CertNameRef pCertName, CFArrayRef where, CFStringRef key,
+                         CFStringRef name, CFStringRef value)
+{
+    if (CFStringCompareWithOptions(name, key, CFRangeMake(0, CFStringGetLength(name)), kCFCompareCaseInsensitive)
+        == kCFCompareEqualTo)
+    {
+        CFArrayAppendValue((CFMutableArrayRef)where, value);
+        return 1;
+    }
+    return 0;
+}
+
+int
+appendCertField(CertNameRef pCert, CFStringRef name, CFStringRef value)
+{
+    struct {
+        CFArrayRef field;
+        CFStringRef key;
+    } fields[] = {
+        { pCert->organization, kCertNameOrganization},
+        { pCert->organizationalUnit, kCertNameOrganizationalUnit},
+        { pCert->countryName, kCertNameCountry},
+        { pCert->localityName, kCertNameLocality},
+        { pCert->stateName, kCertNameState},
+        { pCert->commonName, kCertNameCommonName},
+        { pCert->emailAddress, kCertNameEmail},
+    };
+    int i;
+    int ret = 0;
+
+    for (i = 0; i<sizeof(fields)/sizeof(fields[0]); i++)
+        ret += tryAppendSingleCertField(pCert, fields[i].field, fields[i].key, name, value);
+    return ret;
+}
+
+int
+parseCertName(CFStringRef nameDesc, CFMutableArrayRef names)
+{
+    CFArrayRef nameStrings = CFStringCreateArrayBySeparatingStrings(NULL, nameDesc, kCertNameFwdSlash);
+    int count = CFArrayGetCount(nameStrings);
+    int i;
+    int ret = 1;
+
+    CertNameRef pCertName = createCertName();
+
+    for (i = 0; i < count; i++)
+    {
+        CFMutableStringRef dn = CFStringCreateMutableCopy(NULL, 0, CFArrayGetValueAtIndex(nameStrings, i));
+        CFStringTrimWhitespace(dn);
+
+        CFStringRef name, value;
+
+        if (!parseNameComponent(dn, &name, &value))
+        {
+            ret = 0;
+        }
+
+        if (!name || !value)
+        {
+            if (name)
+            {
+                CFRelease(name);
+            }
+
+            if (value)
+            {
+                CFRelease(value);
+            }
+            if (name && !value)
+            {
+                ret = 0;
+            }
+
+            CFRelease(dn);
+            continue;
+        }
+
+        if (!appendCertField(pCertName, name, value))
+        {
+            ret = 0;
+        }
+        CFRelease(name);
+        CFRelease(value);
+        CFRelease(dn);
+    }
+
+    CFArrayAppendValue(names, pCertName);
+    CFRelease(nameStrings);
+    return ret;
+}
+
+int
+arrayParseDescDataPair(const void *val, void *context)
+{
+    DescDataRef pDescData = (DescDataRef)val;
+    CertDataRef pCertData = (CertDataRef)context;
+    int ret = 1;
+
+    if (!pDescData->name || !pDescData->value)
+    {
+        return 0;
+    }
+
+    if (CFStringCompareWithOptions(pDescData->name, kCertDataSubjectName, CFRangeMake(0, CFStringGetLength(pDescData->name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+    {
+        ret = parseCertName(pDescData->value, (CFMutableArrayRef)pCertData->subject);
+    }
+    else if (CFStringCompareWithOptions(pDescData->name, kCertDataIssuerName, CFRangeMake(0, CFStringGetLength(pDescData->name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+    {
+        ret = parseCertName(pDescData->value, (CFMutableArrayRef)pCertData->issuer);
+    }
+    else if (CFStringCompareWithOptions(pDescData->name, kCertDataSha1Name, CFRangeMake(0, CFStringGetLength(pDescData->name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+    {
+        pCertData->sha1 = CFRetain(pDescData->value);
+    }
+    else if (CFStringCompareWithOptions(pDescData->name, kCertDataMd5Name, CFRangeMake(0, CFStringGetLength(pDescData->name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+    {
+        pCertData->md5 = CFRetain(pDescData->value);
+    }
+    else if (CFStringCompareWithOptions(pDescData->name, kCertDataSerialName, CFRangeMake(0, CFStringGetLength(pDescData->name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+    {
+        pCertData->serial = CFRetain(pDescData->value);
+    }
+    else
+    {
+        return 0;
+    }
+
+    return ret;
+}
+
+CertDataRef
+createCertDataFromString(const char *description)
+{
+    CertDataRef pCertData = (CertDataRef)malloc(sizeof(CertData));
+    pCertData->subject = CFArrayCreateMutable(NULL, 0, NULL);
+    pCertData->issuer = CFArrayCreateMutable(NULL, 0, NULL);
+    pCertData->sha1 = NULL;
+    pCertData->md5 = NULL;
+    pCertData->serial = NULL;
+
+    CFArrayRef pairs = createDescDataPairs(description);
+    for (int i = 0; i<CFArrayGetCount(pairs); i++)
+        if (!arrayParseDescDataPair(CFArrayGetValueAtIndex(pairs, i), pCertData))
+        {
+            arrayDestroyDescData(pCertData, NULL);
+            CFArrayApplyFunction(pairs, CFRangeMake(0, CFArrayGetCount(pairs)), arrayDestroyDescData, NULL);
+            CFRelease(pairs);
+            return 0;
+        }
+
+    CFArrayApplyFunction(pairs, CFRangeMake(0, CFArrayGetCount(pairs)), arrayDestroyDescData, NULL);
+    CFRelease(pairs);
+    return pCertData;
+}
+
+void
+arrayDestroyCertName(const void *val, void *context)
+{
+    CertNameRef pCertName = (CertNameRef)val;
+    destroyCertName(pCertName);
+}
+
+void
+destroyCertData(CertDataRef pCertData)
+{
+    if (pCertData->subject)
+    {
+        CFArrayApplyFunction(pCertData->subject, CFRangeMake(0, CFArrayGetCount(pCertData->subject)), arrayDestroyCertName, NULL);
+        CFRelease(pCertData->subject);
+    }
+
+    if (pCertData->issuer)
+    {
+        CFArrayApplyFunction(pCertData->issuer, CFRangeMake(0, CFArrayGetCount(pCertData->issuer)), arrayDestroyCertName, NULL);
+        CFRelease(pCertData->issuer);
+    }
+
+    if (pCertData->sha1)
+    {
+        CFRelease(pCertData->sha1);
+    }
+
+    if (pCertData->md5)
+    {
+        CFRelease(pCertData->md5);
+    }
+
+    if (pCertData->serial)
+    {
+        CFRelease(pCertData->serial);
+    }
+
+    free(pCertData);
+}
+
+bool
+stringArrayMatchesTemplate(CFArrayRef strings, CFArrayRef templateArray)
+{
+    int templateCount, stringCount, i;
+
+    templateCount = CFArrayGetCount(templateArray);
+
+    if (templateCount > 0)
+    {
+        stringCount = CFArrayGetCount(strings);
+        if (stringCount != templateCount)
+        {
+            return false;
+        }
+
+        for (i = 0; i < stringCount; i++)
+        {
+            CFStringRef str, template;
+
+            template = (CFStringRef)CFArrayGetValueAtIndex(templateArray, i);
+            str = (CFStringRef)CFArrayGetValueAtIndex(strings, i);
+
+            if (CFStringCompareWithOptions(template, str, CFRangeMake(0, CFStringGetLength(template)), kCFCompareCaseInsensitive) != kCFCompareEqualTo)
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+
+}
+
+bool
+certNameMatchesTemplate(CertNameRef pCertName, CertNameRef pTemplate)
+{
+    if (!stringArrayMatchesTemplate(pCertName->countryName, pTemplate->countryName))
+    {
+        return false;
+    }
+    else if (!stringArrayMatchesTemplate(pCertName->organization, pTemplate->organization))
+    {
+        return false;
+    }
+    else if (!stringArrayMatchesTemplate(pCertName->organizationalUnit, pTemplate->organizationalUnit))
+    {
+        return false;
+    }
+    else if (!stringArrayMatchesTemplate(pCertName->commonName, pTemplate->commonName))
+    {
+        return false;
+    }
+    else if (!stringArrayMatchesTemplate(pCertName->emailAddress, pTemplate->emailAddress))
+    {
+        return false;
+    }
+    else if (!stringArrayMatchesTemplate(pCertName->stateName, pTemplate->stateName))
+    {
+        return false;
+    }
+    else if (!stringArrayMatchesTemplate(pCertName->localityName, pTemplate->localityName))
+    {
+        return false;
+    }
+    else
+    {
+        return true;
+    }
+}
+
+bool
+certNameArrayMatchesTemplate(CFArrayRef certNameArray, CFArrayRef templateArray)
+{
+    int templateCount, certCount, i;
+
+    templateCount = CFArrayGetCount(templateArray);
+
+    if (templateCount > 0)
+    {
+        certCount = CFArrayGetCount(certNameArray);
+        if (certCount != templateCount)
+        {
+            return false;
+        }
+
+        for (i = 0; i < certCount; i++)
+        {
+            CertNameRef pName, pTemplateName;
+
+            pTemplateName = (CertNameRef)CFArrayGetValueAtIndex(templateArray, i);
+            pName = (CertNameRef)CFArrayGetValueAtIndex(certNameArray, i);
+
+            if (!certNameMatchesTemplate(pName, pTemplateName))
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool
+hexStringMatchesTemplate(CFStringRef str, CFStringRef template)
+{
+    if (template)
+    {
+        if (!str)
+        {
+            return false;
+        }
+
+        CFMutableStringRef strMutable, templateMutable;
+
+        strMutable = CFStringCreateMutableCopy(NULL, 0, str);
+        templateMutable = CFStringCreateMutableCopy(NULL, 0, template);
+
+        CFStringFindAndReplace(strMutable, kStringSpace, kStringEmpty, CFRangeMake(0, CFStringGetLength(strMutable)), 0);
+        CFStringFindAndReplace(templateMutable, kStringSpace, kStringEmpty, CFRangeMake(0, CFStringGetLength(templateMutable)), 0);
+
+        CFComparisonResult result = CFStringCompareWithOptions(templateMutable, strMutable, CFRangeMake(0, CFStringGetLength(templateMutable)), kCFCompareCaseInsensitive);
+
+        CFRelease(strMutable);
+        CFRelease(templateMutable);
+
+        if (result != kCFCompareEqualTo)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool
+certDataMatchesTemplate(CertDataRef pCertData, CertDataRef pTemplate)
+{
+    if (!certNameArrayMatchesTemplate(pCertData->subject, pTemplate->subject))
+    {
+        return false;
+    }
+
+    if (!certNameArrayMatchesTemplate(pCertData->issuer, pTemplate->issuer))
+    {
+        return false;
+    }
+
+    if (!hexStringMatchesTemplate(pCertData->sha1, pTemplate->sha1))
+    {
+        return false;
+    }
+
+    if (!hexStringMatchesTemplate(pCertData->md5, pTemplate->md5))
+    {
+        return false;
+    }
+
+    if (!hexStringMatchesTemplate(pCertData->serial, pTemplate->serial))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool
+certExpired(SecCertificateRef certificate)
+{
+    bool result;
+    CFDateRef notAfter = GetDateFieldFromCertificate(certificate, kSecOIDX509V1ValidityNotAfter);
+    CFDateRef notBefore = GetDateFieldFromCertificate(certificate, kSecOIDX509V1ValidityNotBefore);
+    CFDateRef now = CFDateCreate(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent());
+
+    if (!notAfter || !notBefore || !now)
+    {
+        warnx("GetDateFieldFromCertificate() returned NULL");
+        result = true;
+    }
+    else
+    {
+        if (CFDateCompare(notBefore, now, NULL) != kCFCompareLessThan
+            || CFDateCompare(now, notAfter, NULL) != kCFCompareLessThan)
+        {
+            result = true;
+        }
+        else
+        {
+            result = false;
+        }
+    }
+
+    CFRelease(notAfter);
+    CFRelease(notBefore);
+    CFRelease(now);
+    return result;
+}
+
+SecIdentityRef
+findIdentity(CertDataRef pCertDataTemplate)
+{
+    const void *keys[] = {
+        kSecClass,
+        kSecReturnRef,
+        kSecMatchLimit
+    };
+    const void *values[] = {
+        kSecClassIdentity,
+        kCFBooleanTrue,
+        kSecMatchLimitAll
+    };
+    CFArrayRef result = NULL;
+
+    CFDictionaryRef query = CFDictionaryCreate(NULL, keys, values,
+                                               sizeof(keys) / sizeof(*keys),
+                                               &kCFTypeDictionaryKeyCallBacks,
+                                               &kCFTypeDictionaryValueCallBacks);
+    OSStatus status = SecItemCopyMatching(query, (CFTypeRef *)&result);
+    CFRelease(query);
+    if (status != noErr)
+    {
+        warnx("No identities in keychain found");
+        return NULL;
+    }
+
+    SecIdentityRef bestIdentity = NULL;
+    CFDateRef bestNotBeforeDate = NULL;
+
+    for (int i = 0; i<CFArrayGetCount(result); i++)
+    {
+        SecIdentityRef identity = (SecIdentityRef)CFArrayGetValueAtIndex(result, i);
+        if (identity == NULL)
+        {
+            warnx("identity == NULL");
+            continue;
+        }
+
+        SecCertificateRef certificate = NULL;
+        SecIdentityCopyCertificate(identity, &certificate);
+        if (certificate == NULL)
+        {
+            warnx("SecIdentityCopyCertificate() returned NULL");
+            continue;
+        }
+
+        CertDataRef pCertData2 = createCertDataFromCertificate(certificate);
+        if (pCertData2 == NULL)
+        {
+            warnx("createCertDataFromCertificate() returned NULL");
+            goto release_cert;
+        }
+        bool bMatches = certDataMatchesTemplate(pCertData2, pCertDataTemplate);
+        bool bExpired = certExpired(certificate);
+        destroyCertData(pCertData2);
+
+        if (bMatches && !bExpired)
+        {
+            CFDateRef notBeforeDate = GetDateFieldFromCertificate(certificate, kSecOIDX509V1ValidityNotBefore);
+            if (!notBeforeDate)
+            {
+                warnx("GetDateFieldFromCertificate() returned NULL");
+                goto release_cert;
+            }
+            if (bestIdentity == NULL)
+            {
+                CFRetain(identity);
+                bestIdentity = identity;
+
+                bestNotBeforeDate = notBeforeDate;
+                CFRetain(notBeforeDate);
+            }
+            else if (CFDateCompare(bestNotBeforeDate, notBeforeDate, NULL) == kCFCompareLessThan)
+            {
+                CFRelease(bestIdentity);
+                CFRetain(identity);
+                bestIdentity = identity;
+
+                bestNotBeforeDate = notBeforeDate;
+                CFRetain(notBeforeDate);
+            }
+            CFRelease(notBeforeDate);
+        }
+release_cert:
+        CFRelease(certificate);
+    }
+    CFRelease(result);
+
+    return bestIdentity;
+}

--- a/tunnelblick/cert_data.c
+++ b/tunnelblick/cert_data.c
@@ -47,7 +47,7 @@
 
 #include "cert_data.h"
 #include <CommonCrypto/CommonDigest.h>
-#include <openssl/ssl.h>
+#include <stdio.h>
 
 #include "common_osx.h"
 #include "crypto_osx.h"
@@ -258,6 +258,7 @@ createCertDataFromCertificate(SecCertificateRef certificate)
     CFDataRef serial = SecCertificateCopySerialNumber(certificate, NULL);
     pCertData->serial = createHexString((unsigned char *)CFDataGetBytePtr(serial), CFDataGetLength(serial));
     CFRelease(serial);
+    CFRelease(data);
 
     return pCertData;
 }
@@ -384,6 +385,7 @@ parseNameComponent(CFStringRef dn, CFStringRef *pName, CFStringRef *pValue)
 
     if (CFArrayGetCount(nameStrings) != 2)
     {
+        CFRelease(nameStrings);
         return 0;
     }
 
@@ -432,7 +434,7 @@ appendCertField(CertNameRef pCert, CFStringRef name, CFStringRef value)
     int i;
     int ret = 0;
 
-    for (i = 0; i<sizeof(fields)/sizeof(fields[0]); i++)
+    for (i = 0; (unsigned long) i < sizeof(fields)/sizeof(fields[0]); i++)
         ret += tryAppendSingleCertField(pCert, fields[i].field, fields[i].key, name, value);
     return ret;
 }
@@ -789,9 +791,9 @@ certExpired(SecCertificateRef certificate)
         }
     }
 
-    CFRelease(notAfter);
-    CFRelease(notBefore);
-    CFRelease(now);
+    if (notAfter) CFRelease(notAfter);
+    if (notBefore) CFRelease(notBefore);
+    if (now) CFRelease(now);
     return result;
 }
 

--- a/tunnelblick/cert_data.c
+++ b/tunnelblick/cert_data.c
@@ -1,4 +1,25 @@
 /*
+ *  Modifications copyright 2017 Pavel Kondratiev <kaloprominat@yandex.ru>
+ *  All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  or see http://www.gnu.org/licenses/.
+ */
+/*
  *  OpenVPN -- An application to securely tunnel IP networks
  *             over a single UDP port, with support for SSL/TLS-based
  *             session authentication and key exchange,

--- a/tunnelblick/cert_data.h
+++ b/tunnelblick/cert_data.h
@@ -1,0 +1,51 @@
+/*
+ *  OpenVPN -- An application to securely tunnel IP networks
+ *             over a single UDP port, with support for SSL/TLS-based
+ *             session authentication and key exchange,
+ *             packet encryption, packet authentication, and
+ *             packet compression.
+ *
+ *  Copyright (C) 2010 Brian Raderman <brian@irregularexpression.org>
+ *  Copyright (C) 2013-2015 Vasily Kulikov <segoon@openwall.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+#ifndef __cert_data_h__
+#define __cert_data_h__
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+
+typedef struct _CertData
+{
+    CFArrayRef subject;
+    CFArrayRef issuer;
+    CFStringRef serial;
+    CFStringRef md5, sha1;
+} CertData, *CertDataRef;
+
+CertDataRef createCertDataFromCertificate(SecCertificateRef certificate);
+
+CertDataRef createCertDataFromString(const char *description);
+
+void destroyCertData(CertDataRef pCertData);
+
+bool certDataMatchesTemplate(CertDataRef pCertData, CertDataRef pTemplate);
+
+void printCertData(CertDataRef pCertData);
+
+SecIdentityRef findIdentity(CertDataRef pCertDataTemplate);
+
+#endif /* ifndef __cert_data_h__ */

--- a/tunnelblick/cert_data.h
+++ b/tunnelblick/cert_data.h
@@ -1,4 +1,25 @@
 /*
+ *  Modifications copyright 2017 Pavel Kondratiev <kaloprominat@yandex.ru>
+ *  All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  or see http://www.gnu.org/licenses/.
+ */
+/*
  *  OpenVPN -- An application to securely tunnel IP networks
  *             over a single UDP port, with support for SSL/TLS-based
  *             session authentication and key exchange,

--- a/tunnelblick/common_osx.c
+++ b/tunnelblick/common_osx.c
@@ -1,0 +1,101 @@
+/*
+ *  OpenVPN -- An application to securely tunnel IP networks
+ *             over a single UDP port, with support for SSL/TLS-based
+ *             session authentication and key exchange,
+ *             packet encryption, packet authentication, and
+ *             packet compression.
+ *
+ *  Copyright (C) 2010 Brian Raderman <brian@irregularexpression.org>
+ *  Copyright (C) 2013-2015 Vasily Kulikov <segoon@openwall.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+/*
+ #include "config.h"
+ #include "syshead.h"
+ #include "common.h"
+ #include "buffer.h"
+ #include "error.h"
+ */
+
+#include "common_osx.h"
+#include <err.h>
+
+void
+printCFString(CFStringRef str)
+{
+    CFIndex bufferLength = CFStringGetLength(str) + 1;
+    char *pBuffer = (char *)malloc(sizeof(char) * bufferLength);
+    CFStringGetCString(str, pBuffer, bufferLength, kCFStringEncodingUTF8);
+    warnx("%s\n", pBuffer);
+    free(pBuffer);
+}
+
+char *
+cfstringToCstr(CFStringRef str)
+{
+    CFIndex bufferLength = CFStringGetLength(str) + 1;
+    char *pBuffer = (char *)malloc(sizeof(char) * bufferLength);
+    CFStringGetCString(str, pBuffer, bufferLength, kCFStringEncodingUTF8);
+    return pBuffer;
+}
+
+void
+appendHexChar(CFMutableStringRef str, unsigned char halfByte)
+{
+    if (halfByte < 10)
+    {
+        CFStringAppendFormat(str, NULL, CFSTR("%d"), halfByte);
+    }
+    else
+    {
+        char tmp[2] = {'A'+halfByte-10, 0};
+        CFStringAppendCString(str, tmp, kCFStringEncodingUTF8);
+    }
+}
+
+CFStringRef
+createHexString(unsigned char *pData, int length)
+{
+    unsigned char byte, low, high;
+    int i;
+    CFMutableStringRef str = CFStringCreateMutable(NULL, 0);
+
+    for (i = 0; i < length; i++)
+    {
+        byte = pData[i];
+        low = byte & 0x0F;
+        high = (byte >> 4);
+
+        appendHexChar(str, high);
+        appendHexChar(str, low);
+
+        if (i != (length - 1))
+        {
+            CFStringAppendCString(str, " ", kCFStringEncodingUTF8);
+        }
+    }
+
+    return str;
+}
+
+void
+printHex(unsigned char *pData, int length)
+{
+    CFStringRef hexStr = createHexString(pData, length);
+    printCFString(hexStr);
+    CFRelease(hexStr);
+}

--- a/tunnelblick/common_osx.c
+++ b/tunnelblick/common_osx.c
@@ -1,4 +1,25 @@
 /*
+ *  Modifications copyright 2017 Pavel Kondratiev <kaloprominat@yandex.ru>
+ *  All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  or see http://www.gnu.org/licenses/.
+ */
+/*
  *  OpenVPN -- An application to securely tunnel IP networks
  *             over a single UDP port, with support for SSL/TLS-based
  *             session authentication and key exchange,

--- a/tunnelblick/common_osx.h
+++ b/tunnelblick/common_osx.h
@@ -47,6 +47,7 @@
 #ifndef __common_osx_h__
 #define __common_osx_h__
 
+#include <stdio.h>
 #include <CoreFoundation/CoreFoundation.h>
 
 void printCFString(CFStringRef str);

--- a/tunnelblick/common_osx.h
+++ b/tunnelblick/common_osx.h
@@ -1,0 +1,39 @@
+/*
+ *  OpenVPN -- An application to securely tunnel IP networks
+ *             over a single UDP port, with support for SSL/TLS-based
+ *             session authentication and key exchange,
+ *             packet encryption, packet authentication, and
+ *             packet compression.
+ *
+ *  Copyright (C) 2010 Brian Raderman <brian@irregularexpression.org>
+ *  Copyright (C) 2013-2015 Vasily Kulikov <segoon@openwall.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef __common_osx_h__
+#define __common_osx_h__
+
+#include <CoreFoundation/CoreFoundation.h>
+
+void printCFString(CFStringRef str);
+
+char *cfstringToCstr(CFStringRef str);
+
+CFStringRef createHexString(unsigned char *pData, int length);
+
+void printHex(unsigned char *pData, int length);
+
+#endif /*__Common_osx_h__ */

--- a/tunnelblick/common_osx.h
+++ b/tunnelblick/common_osx.h
@@ -1,4 +1,25 @@
 /*
+ *  Modifications copyright 2017 Pavel Kondratiev <kaloprominat@yandex.ru>
+ *  All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  or see http://www.gnu.org/licenses/.
+ */
+/*
  *  OpenVPN -- An application to securely tunnel IP networks
  *             over a single UDP port, with support for SSL/TLS-based
  *             session authentication and key exchange,

--- a/tunnelblick/crypto_osx.c
+++ b/tunnelblick/crypto_osx.c
@@ -1,0 +1,80 @@
+/*
+ *  OpenVPN -- An application to securely tunnel IP networks
+ *             over a single UDP port, with support for SSL/TLS-based
+ *             session authentication and key exchange,
+ *             packet encryption, packet authentication, and
+ *             packet compression.
+ *
+ *  Copyright (C) 2010 Brian Raderman <brian@irregularexpression.org>
+ *  Copyright (C) 2013-2015 Vasily Kulikov <segoon@openwall.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+
+#include <CommonCrypto/CommonDigest.h>
+#include <Security/SecKey.h>
+#include <Security/Security.h>
+
+#include "crypto_osx.h"
+#include <err.h>
+
+void
+printErrorMsg(const char *func, CFErrorRef error)
+{
+    CFStringRef desc = CFErrorCopyDescription(error);
+    warnx("%s failed: %s", func, CFStringGetCStringPtr(desc, kCFStringEncodingUTF8));
+    CFRelease(desc);
+}
+
+void
+printErrorStatusMsg(const char *func, OSStatus status)
+{
+    CFStringRef error;
+    error = SecCopyErrorMessageString(status, NULL);
+    if (error)
+    {
+        warnx("%s failed: %s", func, CFStringGetCStringPtr(error, kCFStringEncodingUTF8));
+        CFRelease(error);
+    }
+    else
+    {
+        warnx("%s failed: %X", func, (int)status);
+    }
+}
+
+void
+signData(SecIdentityRef identity, const uint8_t *from, int flen, uint8_t *to, size_t *tlen)
+{
+    SecKeyRef privateKey = NULL;
+    OSStatus status;
+
+    status = SecIdentityCopyPrivateKey(identity,  &privateKey);
+    if (status != noErr)
+    {
+        printErrorStatusMsg("signData: SecIdentityCopyPrivateKey", status);
+        *tlen = 0;
+        return;
+    }
+
+    status = SecKeyRawSign(privateKey, kSecPaddingPKCS1, from, flen, to, tlen);
+    CFRelease(privateKey);
+    if (status != noErr)
+    {
+        printErrorStatusMsg("signData: SecKeyRawSign", status);
+        *tlen = 0;
+        return;
+    }
+}

--- a/tunnelblick/crypto_osx.c
+++ b/tunnelblick/crypto_osx.c
@@ -1,4 +1,25 @@
 /*
+ *  Modifications copyright 2017 Pavel Kondratiev <kaloprominat@yandex.ru>
+ *  All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  or see http://www.gnu.org/licenses/.
+ */
+/*
  *  OpenVPN -- An application to securely tunnel IP networks
  *             over a single UDP port, with support for SSL/TLS-based
  *             session authentication and key exchange,

--- a/tunnelblick/crypto_osx.h
+++ b/tunnelblick/crypto_osx.h
@@ -49,6 +49,7 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/Security.h>
+#include <stdio.h>
 
 extern OSStatus SecKeyRawSign(
     SecKeyRef key,

--- a/tunnelblick/crypto_osx.h
+++ b/tunnelblick/crypto_osx.h
@@ -1,0 +1,45 @@
+/*
+ *  OpenVPN -- An application to securely tunnel IP networks
+ *             over a single UDP port, with support for SSL/TLS-based
+ *             session authentication and key exchange,
+ *             packet encryption, packet authentication, and
+ *             packet compression.
+ *
+ *  Copyright (C) 2010 Brian Raderman <brian@irregularexpression.org>
+ *  Copyright (C) 2013-2015 Vasily Kulikov <segoon@openwall.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef __crypto_osx_h__
+#define __crypto_osx_h__
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+
+extern OSStatus SecKeyRawSign(
+    SecKeyRef key,
+    SecPadding padding,
+    const uint8_t *dataToSign,
+    size_t dataToSignLen,
+    uint8_t *sig,
+    size_t *sigLen
+    );
+
+void signData(SecIdentityRef identity, const uint8_t *from, int flen, uint8_t *to, size_t *tlen);
+
+void printErrorMsg(const char *func, CFErrorRef error);
+
+#endif /*__crypto_osx_h__ */

--- a/tunnelblick/crypto_osx.h
+++ b/tunnelblick/crypto_osx.h
@@ -1,4 +1,25 @@
 /*
+ *  Modifications copyright 2017 Pavel Kondratiev <kaloprominat@yandex.ru>
+ *  All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  or see http://www.gnu.org/licenses/.
+ */
+/*
  *  OpenVPN -- An application to securely tunnel IP networks
  *             over a single UDP port, with support for SSL/TLS-based
  *             session authentication and key exchange,

--- a/tunnelblick/keychain_mcd.c
+++ b/tunnelblick/keychain_mcd.c
@@ -1,0 +1,123 @@
+/*
+ *  Copyright 2017 Pavel Kondratiev <kaloprominat@yandex.ru>
+ *  All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  or see http://www.gnu.org/licenses/.
+ */
+
+/*
+ *  This file contains modified functions from openvpn keychain-mcd main.c module
+ *  https://github.com/OpenVPN/openvpn/blob/master/contrib/keychain-mcd/main.c
+ */
+
+#include "keychain_mcd.h"
+
+SecIdentityRef template_to_identity(const char *template, keychainMcdTemplateSearchResult *result) {
+    SecIdentityRef identity;
+    CertDataRef pCertDataTemplate = createCertDataFromString(template);
+    if (pCertDataTemplate == NULL)
+    {
+        *result = templateSearchResultBadTemplate;
+        return NULL;
+    }
+    identity = findIdentity(pCertDataTemplate);
+    if (identity == NULL)
+    {
+        *result = templateSearchResultNotFound;
+        return NULL;
+    }
+    destroyCertData(pCertDataTemplate);
+    result = templateSearchResultSuccess;
+    return identity;
+}
+
+char * get_certificate(SecIdentityRef identity, keychainMcdGetCertificateResult *result) {
+
+    OSStatus status;
+    SecCertificateRef certificate = NULL;
+    CFDataRef data;
+    const unsigned char *cert;
+    size_t cert_len;
+    char *result_b64;
+
+    status = SecIdentityCopyCertificate(identity, &certificate);
+    if (status != noErr)
+    {
+        *result = getCertificateResultError;
+        return strdup(GetMacOSStatusErrorString(status));
+    }
+
+    data = SecCertificateCopyData(certificate);
+    if (data == NULL)
+    {
+        *result = getCertificateResultNull;
+        return NULL;
+    }
+
+    cert = CFDataGetBytePtr(data);
+    cert_len = CFDataGetLength(data);
+
+    base64_encode(cert, cert_len, &result_b64);
+#if 0
+    fprintf(stderr, "certificate %s\n", result_b64);
+#endif
+
+    CFRelease(data);
+    CFRelease(certificate);
+
+    *result = getCertificateResultSuccess;
+    return result_b64;
+}
+
+char * rsasign(SecIdentityRef identity, const char *input, keychainMcdRsasignResult *result) {
+
+    const char *input_b64 = strchr(input, ':') + 1;
+    char *input_binary;
+    int input_len;
+    char *output_binary;
+    size_t output_len;
+    char *output_b64;
+
+    input_len = strlen(input_b64)*8/6 + 4;
+    input_binary = malloc(input_len);
+    input_len = base64_decode(input_b64, input_binary, input_len);
+
+    if (input_len < 0)
+    {
+        *result = rsasignResultB64Error;
+        return NULL;
+    }
+
+    output_len = 1024;
+    output_binary = malloc(output_len);
+    signData(identity, (const uint8_t *)input_binary, input_len, (uint8_t *)output_binary, &output_len);
+    if (output_len == 0)
+    {
+        *result = rsasignResultError;
+        return NULL;
+    }
+
+    base64_encode(output_binary, output_len, &output_b64);
+
+    free(input_binary);
+    free(output_binary);
+
+    *result = rsasignResultSuccess;
+    return output_b64;
+
+}

--- a/tunnelblick/keychain_mcd.h
+++ b/tunnelblick/keychain_mcd.h
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2017 Pavel Kondratiev <kaloprominat@yandex.ru>
+ *  All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *  or see http://www.gnu.org/licenses/.
+ */
+
+
+#ifndef keychain_mcd_h
+#define keychain_mcd_h
+
+#include <stdio.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/un.h>
+#include <err.h>
+#include <netdb.h>
+
+#include <Security/Security.h>
+#include <CoreServices/CoreServices.h>
+
+#include "cert_data.h"
+#include "crypto_osx.h"
+#include "base64.h"
+
+typedef enum
+{
+    templateSearchResultSuccess,
+    templateSearchResultNotFound,
+    templateSearchResultBadTemplate
+} keychainMcdTemplateSearchResult;
+
+typedef enum {
+    getCertificateResultSuccess,
+    getCertificateResultNull,
+    getCertificateResultError
+} keychainMcdGetCertificateResult;
+
+typedef enum {
+    rsasignResultSuccess,
+    rsasignResultError,
+    rsasignResultB64Error
+} keychainMcdRsasignResult;
+
+
+SecIdentityRef template_to_identity(const char *template, keychainMcdTemplateSearchResult *result);
+char * get_certificate(SecIdentityRef identity, keychainMcdGetCertificateResult *result);
+char * rsasign(SecIdentityRef identity, const char *input, keychainMcdRsasignResult *result);
+
+#endif /* keychain_mcd_h */


### PR DESCRIPTION
hi!

since version 2.4.0 openvpn supports offloading of encryption/decryption operations onto macOS keychain via management interface. It becomes possible by adding to openvpn new configuration option "--management-external-cert" which specifies identity search template for management program.

more details about this feature can be found here:

http://www.mail-archive.com/openvpn-devel@lists.sourceforge.net/msg09717.html
https://sourceforge.net/p/openvpn/mailman/openvpn-devel/thread/20141208115202.GA4807%40cachalot/#msg33125844
https://sourceforge.net/p/openvpn/mailman/openvpn-devel/thread/20150112085121.GA25193%40cachalot/#msg33225603

In order it to work properly, management program should answer to management commands NEED-CERTIFICATE and RSA_SIGN. 

This patch adds some cryptographic modules for working with certificates/keychain related items, and two new reactions on commands "NEED-CERTIFICATE" and "RSA_SIGN" to VPNConnection.m. With this patch, it makes possible to use keychain stored certificates/keys for openvpn authentication.

Code based on keychain management client daemon example, contributed to openvpn as en example for this feature: https://github.com/OpenVPN/openvpn/tree/master/contrib/keychain-mcd.

As the result, you may specify openvpn config like

>...
>client
>tls-client
>management-external-cert "macosx-keychain:subject:CN=your certificate cn"
>management-external-key

and Tunnelblick asks keychain access and provides valid signature to openvpn while connecting.

![2017-04-11_12-24-01](https://cloud.githubusercontent.com/assets/2452080/24902129/e1c67ff6-1eb1-11e7-95e5-14378b25208a.png)

This also allows to use same way certificates/keys, stored on some external token, which is shown as own keychain in keychain access.

Successfuly tested with rutoken: https://www.rutoken.ru/products/all/rutoken-ecp/

**UPD:**
Successfuly tested with Aladdin-rd eToken (SafeNet eToken 5100)