### PR TITLE
Check for lack of IP addr before assuming DHCP

### DIFF
--- a/tunnelblick/client.up.tunnelblick.sh
+++ b/tunnelblick/client.up.tunnelblick.sh
@@ -1471,8 +1471,17 @@ if ${ARG_TAP} ; then
 	# Still need to do: Look for route-gateway dhcp (TAP isn't always DHCP)
 	bRouteGatewayIsDhcp="false"
 	if [ -z "${route_vpn_gateway}" -o "$route_vpn_gateway" == "dhcp" -o "$route_vpn_gateway" == "DHCP" ]; then
-		bRouteGatewayIsDhcp="true"
+		# Check if $dev already has an ip configuration
+		hasIp="$(ifconfig ${dev} | grep inet | cut -d ' ' -f 2)"
+		if [ "${hasIp}" ]; then
+			logMessage "Not using DHCP because ${dev} already has an ip configuration."
+		else
+			bRouteGatewayIsDhcp="true"
+		fi
 	fi
+	
+	
+	
 
 	if [ "$bRouteGatewayIsDhcp" == "true" ]; then
 		logDebugMessage "DEBUG: bRouteGatewayIsDhcp is TRUE"


### PR DESCRIPTION
Fixes #402 

We should not assume DHCP just because of a lack of "route_vpn_gateway" env var, this is an open issue on openvpn:  https://community.openvpn.net/openvpn/ticket/668

It seems a safe bet to not use DHCP if there is already an IP address configured (i.e. by openvpn).

Please see further discussion on the issue.  Thanks!