### PR TITLE
Refactor scutil parts of client scripts, fix #379

### DIFF
--- a/tunnelblick/client.4.up.tunnelblick.sh
+++ b/tunnelblick/client.4.up.tunnelblick.sh
@@ -1090,6 +1090,10 @@ configureOpenVpnDns()
 				aNameServers[nNameServerIndex-1]="$( trim "${vOptions[nOptionIndex-1]//dhcp-option DNS /}" )"
 				let nNameServerIndex++
 				;;
+			"dhcp-option DNS6 "*    )
+				aNameServers[nNameServerIndex-1]="$( trim "${vOptions[nOptionIndex-1]//dhcp-option DNS6 /}" )"
+				let nNameServerIndex++
+				;;
 			"dhcp-option WINS "*   )
 				aWinsServers[nWinsServerIndex-1]="$( trim "${vOptions[nOptionIndex-1]//dhcp-option WINS /}" )"
 				let nWinsServerIndex++


### PR DESCRIPTION

Don't edit old service but create new service instead

Fix IPv6 addresses not working (macOS does resolve AAAA too now)

Fix DNS resolver for scoped queries becoming unreachable (old interface
was used with address given by vpn server, probably it could've even
caused dns leak)

Fix copy-paste error in down script

Handle dhcp-option DNS6


I have not tested it on anything other than macOS High Sierra with IPv4 only network connecting to openvpn server giving out IPv4 and IPv6 addresses. Haven't tested on older OS X or on different configurations.

Also, Probably other scripts/executables (i.e. process-network-changes) need to be updated -- please tell me if there's more stuff to fix.

---

IMHO these scripts need to be carefully reviewed/rewritten, with different versions for different OSVER if dropping older OS X support isn't an option.
And SystemConfiguration usage/"schema" needs to be documented too. 