### PR TITLE
reset preferences window animation

### DIFF
--- a/tunnelblick/DBPrefsWindowController.m
+++ b/tunnelblick/DBPrefsWindowController.m
@@ -421,8 +421,8 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
     if ([self shiftSlowsAnimation] && [[[self window] currentEvent] modifierFlags] & NSShiftKeyMask)
 		[viewAnimation setDuration:0.00];
     else
-	
 		[viewAnimation setDuration:0.00];
+	
 	NSDictionary *fadeOutDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
                                        oldView, NSViewAnimationTargetKey,
                                        NSViewAnimationFadeOutEffect, NSViewAnimationEffectKey,

--- a/tunnelblick/DBPrefsWindowController.m
+++ b/tunnelblick/DBPrefsWindowController.m
@@ -419,10 +419,10 @@ static DBPrefsWindowController *_sharedPrefsWindowController = nil;
     [self newViewWillAppear: newView identifier: identifier];
     
     if ([self shiftSlowsAnimation] && [[[self window] currentEvent] modifierFlags] & NSShiftKeyMask)
-		[viewAnimation setDuration:1.25];
+		[viewAnimation setDuration:0.00];
     else
-		[viewAnimation setDuration:0.25];
 	
+		[viewAnimation setDuration:0.00];
 	NSDictionary *fadeOutDictionary = [NSDictionary dictionaryWithObjectsAndKeys:
                                        oldView, NSViewAnimationTargetKey,
                                        NSViewAnimationFadeOutEffect, NSViewAnimationEffectKey,


### PR DESCRIPTION
* reset preferences window animation time
* fix overlay content issues when navigation between
* 📕 Apple HIG
  * https://developer.apple.com/design/human-interface-guidelines/macos/app-architecture/preferences/
  * https://developer.apple.com/design/human-interface-guidelines/macos/windows-and-views/toolbars/
    > Clicking a toolbar item results in an immediate action—such as opening a new window, switching to a different view, [...]—so it doesn’t make sense to imply that there is also a change in state.
* fixes #522

🔗 #528 