### PR TITLE
refine Info Preference view - alignment

### DIFF
--- a/tunnelblick/Preferences.xib
+++ b/tunnelblick/Preferences.xib
@@ -1302,64 +1302,35 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <textField verticalHuggingPriority="750" id="120">
-                    <rect key="frame" x="17" y="359" width="726" height="17"/>
+                    <rect key="frame" x="142" y="353" width="760" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" alignment="center" title="TunnelBlick$" id="121">
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" alignment="left" title="TunnelBlick$" id="121">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
                 <imageView id="118">
-                    <rect key="frame" x="98" y="256" width="96" height="96"/>
+                    <rect key="frame" x="20" y="274" width="96" height="96"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="123"/>
                 </imageView>
-                <scrollView horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" id="479">
-                    <rect key="frame" x="214" y="256" width="686" height="89"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="m5e-Lf-0UP">
-                        <rect key="frame" x="1" y="1" width="684" height="87"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                        <subviews>
-                            <textView importsGraphics="NO" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" usesFontPanel="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" spellingCorrection="YES" smartInsertDelete="YES" id="482">
-                                <rect key="frame" x="0.0" y="0.0" width="684" height="87"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <color key="backgroundColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                <size key="minSize" width="684" height="87"/>
-                                <size key="maxSize" width="923" height="10000000"/>
-                                <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                <size key="minSize" width="684" height="87"/>
-                                <size key="maxSize" width="923" height="10000000"/>
-                            </textView>
-                        </subviews>
-                        <color key="backgroundColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
-                    </clipView>
-                    <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.99294117647058822" horizontal="YES" id="481">
-                        <rect key="frame" x="-100" y="-100" width="87" height="18"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </scroller>
-                    <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.13253012048192769" horizontal="NO" id="480">
-                        <rect key="frame" x="-100" y="-100" width="15" height="87"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </scroller>
-                </scrollView>
                 <scrollView horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" id="459">
-                    <rect key="frame" x="98" y="45" width="802" height="203"/>
+                    <rect key="frame" x="20" y="52" width="880" height="208"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <clipView key="contentView" id="AWE-S3-xdG">
-                        <rect key="frame" x="1" y="1" width="800" height="201"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <rect key="frame" x="1" y="1" width="878" height="206"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView importsGraphics="NO" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" usesFontPanel="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" spellingCorrection="YES" smartInsertDelete="YES" id="462">
-                                <rect key="frame" x="0.0" y="-14" width="800" height="201"/>
+                                <rect key="frame" x="0.0" y="-14" width="878" height="206"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <size key="minSize" width="800" height="201"/>
-                                <size key="maxSize" width="802" height="10000000"/>
+                                <size key="minSize" width="878" height="206"/>
+                                <size key="maxSize" width="878" height="10000000"/>
                                 <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                <size key="minSize" width="800" height="201"/>
-                                <size key="maxSize" width="802" height="10000000"/>
+                                <size key="minSize" width="878" height="206"/>
+                                <size key="maxSize" width="878" height="10000000"/>
                             </textView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -1374,10 +1345,10 @@
                     </scroller>
                 </scrollView>
                 <textField verticalHuggingPriority="750" id="402">
-                    <rect key="frame" x="44" y="20" width="859" height="17"/>
+                    <rect key="frame" x="18" y="21" width="884" height="17"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Copyright$" id="403">
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
@@ -1394,6 +1365,35 @@
                         <outlet property="nextKeyView" destination="120" id="800"/>
                     </connections>
                 </button>
+                <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" id="479">
+                    <rect key="frame" x="139" y="274" width="761" height="71"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="m5e-Lf-0UP">
+                        <rect key="frame" x="0.0" y="0.0" width="761" height="71"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView importsGraphics="NO" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" usesFontPanel="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" spellingCorrection="YES" smartInsertDelete="YES" id="482">
+                                <rect key="frame" x="0.0" y="0.0" width="761" height="71"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <color key="backgroundColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                <size key="minSize" width="761" height="71"/>
+                                <size key="maxSize" width="923" height="10000000"/>
+                                <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                <size key="minSize" width="761" height="71"/>
+                                <size key="maxSize" width="923" height="10000000"/>
+                            </textView>
+                        </subviews>
+                        <color key="backgroundColor" name="windowBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </clipView>
+                    <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.99294117647058822" horizontal="YES" id="481">
+                        <rect key="frame" x="-100" y="-100" width="87" height="18"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </scroller>
+                    <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="0.13253012048192769" horizontal="NO" id="480">
+                        <rect key="frame" x="-100" y="-100" width="15" height="87"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </scroller>
+                </scrollView>
             </subviews>
             <connections>
                 <outlet property="infoCopyrightTFC" destination="403" id="820"/>


### PR DESCRIPTION
* alignment of pref info view
* align contents left hand
* align title and description
* remove border
* use font mini for copyright typo

| before | after |
|---|---|
| ![Screen Shot 2019-05-22 at 12 44 39 PM](https://user-images.githubusercontent.com/26371/58171101-7962cc00-7c95-11e9-88b7-6d78f47f27c7.png) | ![Screen Shot 2019-05-22 at 1 22 46 PM](https://user-images.githubusercontent.com/26371/58171118-8384ca80-7c95-11e9-936b-f27d7a3ca187.png) |

🔗 #528 