### PR TITLE
remove fixed application name suffix from preferences

### DIFF
--- a/tunnelblick/MyPrefsWindowController.m
+++ b/tunnelblick/MyPrefsWindowController.m
@@ -1501,7 +1501,7 @@ static BOOL firstTimeShowingWindow = TRUE;
         appName = [appName substringToIndex: [appName length] - 4];
     }
     
-    NSString * windowLabel = [NSString stringWithFormat: @"%@ - Tunnelblick", localizeNonLiteral(currentViewName, @"Window title")];
+    NSString * windowLabel = [NSString stringWithFormat: @"%@", localizeNonLiteral(currentViewName, @"Window title")];
 
     if (  [currentViewName isEqualToString: NSLocalizedString(@"Configurations", @"Window title")]  ) {
         VPNConnection * connection = [self selectedConnection];


### PR DESCRIPTION
* remove fixed application name suffix from preferences
  * eg. `Info - Tunnelblick` -> `Info`
* 📕Apple HIG
  * https://developer.apple.com/design/human-interface-guidelines/macos/app-architecture/preferences/
  > **Update the window's title to reflect the currently visible preference pane.**
For example, if your preferences window has a General preference pane, the window’s title should be General when that pane is active.

🔗 #528 