### PR TITLE
fix Warnings label alignment

### DIFF
--- a/tunnelblick/Preferences.xib
+++ b/tunnelblick/Preferences.xib
@@ -775,7 +775,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" id="9">
-                    <rect key="frame" x="20" y="249" width="283" height="17"/>
+                    <rect key="frame" x="19" y="249" width="281" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="W..." id="30">
                         <font key="font" metaFont="system"/>
@@ -795,15 +795,6 @@
                         <outlet property="nextKeyView" destination="1302" id="1319"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" id="128">
-                    <rect key="frame" x="17" y="123" width="283" height="17"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="U..." id="131">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
                 <button id="127" customClass="TBButton">
                     <rect key="frame" x="306" y="122" width="596" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -883,6 +874,15 @@
                     <rect key="frame" x="17" y="207" width="283" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="I..." id="1304">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" id="128">
+                    <rect key="frame" x="17" y="123" width="283" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="U..." id="131">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -1327,10 +1327,10 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <size key="minSize" width="878" height="206"/>
-                                <size key="maxSize" width="878" height="10000000"/>
+                                <size key="maxSize" width="880" height="10000000"/>
                                 <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                 <size key="minSize" width="878" height="206"/>
-                                <size key="maxSize" width="878" height="10000000"/>
+                                <size key="maxSize" width="880" height="10000000"/>
                             </textView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
* fix Warnings label alignment

<img width="211" alt="Screenshot 2019-06-03 at 11 29 23" src="https://user-images.githubusercontent.com/26371/58791642-e3169a80-85f2-11e9-9a93-ae3d919b68e8.png">


| before  | after |
|---|---|
| <img width="1032" alt="Screenshot 2019-06-03 at 11 11 57" src="https://user-images.githubusercontent.com/26371/58791530-ab0f5780-85f2-11e9-9259-92cea10e37b2.png">  | ![Screen Shot 2019-06-03 at 11 18 54 AM](https://user-images.githubusercontent.com/26371/58791553-b2366580-85f2-11e9-920c-cd9ac40a4bd9.png) |

🔗 #528 