### PR TITLE
--secret is only being removed in conjunction with --genkey

### DIFF
--- a/tunnelblick/defines.h
+++ b/tunnelblick/defines.h
@@ -224,7 +224,7 @@
                             @[@"2.3", @"2.5",  @"compat-names", @"no-name-remapping"], \
                             @[@"2.4", @"2.4",  @"tun-ipv6"], \
                             @[@"2.4", @"2.5",  @"client-cert-not-required", @"key-method", @"no-iv", @"no-replay"], \
-                            @[@"2.4", @"2.5?", @"comp-lzo", @"dhcp-release", @"max-routes", @"secret"], \
+                            @[@"2.4", @"2.5?", @"comp-lzo", @"dhcp-release", @"max-routes"], \
                             @[@"2.4", @"2.6",  @"keysize"], \
                             @[@"2.4", @"2.6?", @"ns-cert-type"], \
                             @[@"2.5", @"2.6?", @"compress", @"ncp-disable"] \


### PR DESCRIPTION
See https://community.openvpn.net/openvpn/wiki/DeprecatedOptions?__cf_chl_jschl_tk__=4689b08f0018d0c45915c209d40516ebf85d0f0a-1595849723-0-AdB4zIveQk-R8u6A8qxjqJSXR-q6cSsHinXjmSvbt6LfAsOKoVoGYP_wIVNz-s3K5JL8OuoMsYD59XuJr0OiUu8d1RbkpNb04Ot0rSP2yZ68E3PHbY3nPLOPmqV1ztVCrypc85Qtzk1C4enIAyFafgJ0dmYv_mjzngFYKccpjSbZl7gNoa_uBzOSEHk70gjer_TR-DTK3z9o0yWQv7xNYqOUYHQJvp0yq0SVhXhEMs6qC-ktzChqKeYPzvv_m2OBAualIyKbWkkA3m9N3cQNBnO6OCCdSUrDCLAHWcru33BtXAFkqDVij179mvETxnv2UQ#Option:--secret .

The --genkey case isn't very likely to be done in a configuation file and fed into Tunnelblick.

'secret' is also used in Static Key configurations, where it specifies the static key. This use is not deprecated.

See https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/ (search for "Enable Static Key encryption mode").

We're happy to accept Pull Requests (PRs) for everything **except translations**.

We do translations on Crowdin.com, where they can be voted up or down by other translators.
Then we import translations with the highest vote totals from Crowdin into the Tunnelblick
source code. It's a one-way transfer from Crowdin into the source code – we don't transfer
from the source code into Crowdin, so we don't accept PRs.

Please see [Localizing and Translating Tunnelblick](https://tunnelblick.net/cLocalizeTranslate.html) for details.

Email developers@tunnelblick.net to volunteer to translate.