### PR TITLE
Support for security tokens added

### DIFF
--- a/tunnelblick/AuthAgent.m
+++ b/tunnelblick/AuthAgent.m
@@ -230,6 +230,7 @@ TBSYNTHESIZE_NONOBJECT_GET( BOOL,       showingPassphraseWindow)
     
     NSString * usernameLocal = nil;
     NSString * passwordLocal = nil;
+    NSString * securityTokenLocal = nil;
 
     if (  [self usernameIsInKeychain]  ) {
         usernameLocal = [usernameKeychain password];
@@ -254,9 +255,11 @@ TBSYNTHESIZE_NONOBJECT_GET( BOOL,       showingPassphraseWindow)
     }
 
     NSString * key = [[self displayName] stringByAppendingString: @"-alwaysShowLoginWindow"];
+    NSString * tokenKey = [[self displayName] stringByAppendingString: @"-useSecurityToken"];
     if (   (! passwordLocal)
         || (! usernameLocal)
-        || [gTbDefaults boolForKey: key]  ) {
+				|| [gTbDefaults boolForKey: key]
+        || [gTbDefaults boolForKey: tokenKey]  ) {
         
         // Ask for password and username
 
@@ -291,7 +294,8 @@ TBSYNTHESIZE_NONOBJECT_GET( BOOL,       showingPassphraseWindow)
 
         usernameLocal = [[loginScreen username] stringValue];
         passwordLocal = [[loginScreen password] stringValue];
-        
+        securityTokenLocal = [loginScreen useSecurityTokenChecked] ? [[loginScreen securityToken] stringValue] : @"";
+
         if (  ! usernameLocal  ) {
             NSLog(@"username is nil for Keychain '%@'", [usernameKeychain description]);
             usernameLocal = @"";
@@ -300,7 +304,10 @@ TBSYNTHESIZE_NONOBJECT_GET( BOOL,       showingPassphraseWindow)
             NSLog(@"password is nil for Keychain '%@'", [usernameKeychain description]);
             passwordLocal = @"";
         }
-        
+        if (  ! securityTokenLocal ) {
+					securityTokenLocal = @"";
+			  }
+
         if (   [loginScreen isSaveUsernameInKeychainChecked]  ) {
             
             if (   [loginScreen isSavePasswordInKeychainChecked]  ) {
@@ -345,7 +352,8 @@ TBSYNTHESIZE_NONOBJECT_GET( BOOL,       showingPassphraseWindow)
         [[loginScreen window] close];
     }
     
-    NSArray * array = [NSArray arrayWithObjects: usernameLocal, passwordLocal, nil];
+    NSString * passwordAndToken = [passwordLocal stringByAppendingString:securityTokenLocal];
+    NSArray * array = [NSArray arrayWithObjects: usernameLocal, passwordAndToken, nil];
     return array;
 }
 

--- a/tunnelblick/LoginWindow-RTL.xib
+++ b/tunnelblick/LoginWindow-RTL.xib
@@ -111,7 +111,7 @@ Gw
                                     <outlet property="nextKeyView" destination="86" id="104"/>
                                 </connections>
                             </button>
-                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="86">
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="86" customClass="TBButton">
                                 <rect key="frame" x="18" y="132" width="332" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="check" title="Save password in Keychain" bezelStyle="regularSquare" imagePosition="right" alignment="right" inset="2" id="87">
@@ -200,7 +200,7 @@ Gw
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wn3-me-tYT">
                                 <rect key="frame" x="355" y="95" width="129" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="check" title="SecurityToken" bezelStyle="regularSquare" imagePosition="right" inset="2" id="SZu-oq-kO8">
+                                <buttonCell key="cell" type="check" title="Token" bezelStyle="regularSquare" imagePosition="right" inset="2" id="SZu-oq-kO8">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>

--- a/tunnelblick/LoginWindow-RTL.xib
+++ b/tunnelblick/LoginWindow-RTL.xib
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G22010" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="LoginWindowController">
@@ -17,28 +18,32 @@
                 <outlet property="passwordTFC" destination="47" id="51"/>
                 <outlet property="savePasswordInKeychainCheckbox" destination="86" id="90"/>
                 <outlet property="saveUsernameInKeychainCheckbox" destination="42" id="89"/>
+                <outlet property="securityEyeButton" destination="LS4-oh-7b6" id="8Tl-Hg-kPp"/>
+                <outlet property="securityToken" destination="adg-1U-zFx" id="w7u-hq-5y5"/>
+                <outlet property="useSecurityTokenCheckbox" destination="wn3-me-tYT" id="Lkl-Rx-Cz9"/>
                 <outlet property="username" destination="38" id="64"/>
                 <outlet property="usernameTFC" destination="45" id="54"/>
                 <outlet property="visiblePassword" destination="LOz-xG-e9B" id="Jji-4E-pfj"/>
+                <outlet property="visibleSecurityToken" destination="Sp5-mN-LXU" id="jiR-DC-X4U"/>
                 <outlet property="window" destination="1" id="15"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="ConnectingWindow" animationBehavior="default" id="1">
+        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="ConnectingWindow" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="345" width="500" height="300"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1028"/>
+            <rect key="contentRect" x="196" y="345" width="500" height="350"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
             <view key="contentView" id="2">
-                <rect key="frame" x="0.0" y="0.0" width="500" height="300"/>
+                <rect key="frame" x="0.0" y="0.0" width="500" height="350"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <customView id="27">
-                        <rect key="frame" x="0.0" y="0.0" width="500" height="300"/>
+                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="27">
+                        <rect key="frame" x="0.0" y="0.0" width="500" height="350"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <subviews>
-                            <button verticalHuggingPriority="750" id="9">
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9">
                                 <rect key="frame" x="14" y="36" width="105" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="push" title="O" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="10">
@@ -53,7 +58,7 @@ DQ
                                     <outlet property="nextKeyView" destination="35" id="108"/>
                                 </connections>
                             </button>
-                            <button verticalHuggingPriority="750" id="35">
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="35">
                                 <rect key="frame" x="130" y="36" width="105" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="push" title="C" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="36">
@@ -68,12 +73,12 @@ Gw
                                     <outlet property="nextKeyView" destination="38" id="109"/>
                                 </connections>
                             </button>
-                            <textField verticalHuggingPriority="750" id="38">
-                                <rect key="frame" x="20" y="169" width="328" height="22"/>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="38">
+                                <rect key="frame" x="20" y="219" width="328" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" id="39">
                                     <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                                 <connections>
@@ -81,12 +86,12 @@ Gw
                                     <outlet property="nextKeyView" destination="55" id="102"/>
                                 </connections>
                             </textField>
-                            <textField verticalHuggingPriority="750" id="LOz-xG-e9B">
-                                <rect key="frame" x="107" y="106" width="241" height="22"/>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LOz-xG-e9B">
+                                <rect key="frame" x="107" y="156" width="241" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" baseWritingDirection="rightToLeft" userInterfaceLayoutDirection="rightToLeft" alignment="right" drawsBackground="YES" id="kfU-dL-7KJ">
                                     <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                                 <connections>
@@ -94,8 +99,8 @@ Gw
                                     <outlet property="nextKeyView" destination="55" id="nUJ-wz-iea"/>
                                 </connections>
                             </textField>
-                            <button id="42">
-                                <rect key="frame" x="18" y="145" width="332" height="18"/>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="42">
+                                <rect key="frame" x="18" y="195" width="332" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="check" title="Save username in Keychain" bezelStyle="regularSquare" imagePosition="right" alignment="right" inset="2" id="43">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -106,8 +111,8 @@ Gw
                                     <outlet property="nextKeyView" destination="86" id="104"/>
                                 </connections>
                             </button>
-                            <button id="86">
-                                <rect key="frame" x="18" y="82" width="332" height="18"/>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="86">
+                                <rect key="frame" x="18" y="132" width="332" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="check" title="Save password in Keychain" bezelStyle="regularSquare" imagePosition="right" alignment="right" inset="2" id="87">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -117,8 +122,8 @@ Gw
                                     <outlet property="nextKeyView" destination="9" id="107"/>
                                 </connections>
                             </button>
-                            <textField verticalHuggingPriority="750" id="44">
-                                <rect key="frame" x="353" y="172" width="129" height="17"/>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="44">
+                                <rect key="frame" x="353" y="222" width="129" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Label" id="45">
                                     <font key="font" metaFont="system"/>
@@ -126,8 +131,8 @@ Gw
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" id="46">
-                                <rect key="frame" x="353" y="108" width="129" height="17"/>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="46">
+                                <rect key="frame" x="353" y="158" width="129" height="17"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Label" id="47">
                                     <font key="font" metaFont="system"/>
@@ -135,12 +140,12 @@ Gw
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <secureTextField verticalHuggingPriority="750" id="55">
-                                <rect key="frame" x="48" y="106" width="300" height="22"/>
+                            <secureTextField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="55">
+                                <rect key="frame" x="48" y="156" width="300" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" baseWritingDirection="rightToLeft" userInterfaceLayoutDirection="rightToLeft" drawsBackground="YES" usesSingleLineMode="YES" id="56">
                                     <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <allowedInputSourceLocales>
                                         <string>NSAllRomanInputSourcesLocaleIdentifier</string>
@@ -151,13 +156,13 @@ Gw
                                     <outlet property="nextKeyView" destination="42" id="106"/>
                                 </connections>
                             </secureTextField>
-                            <imageView id="110">
-                                <rect key="frame" x="407" y="206" width="72" height="72"/>
+                            <imageView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="110">
+                                <rect key="frame" x="407" y="256" width="72" height="72"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="111"/>
                             </imageView>
-                            <textField verticalHuggingPriority="750" id="31">
-                                <rect key="frame" x="18" y="204" width="372" height="76"/>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="31">
+                                <rect key="frame" x="18" y="254" width="372" height="76"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" sendsActionOnEndEditing="YES" baseWritingDirection="rightToLeft" userInterfaceLayoutDirection="rightToLeft" title="text" id="32">
                                     <font key="font" metaFont="system"/>
@@ -165,8 +170,8 @@ Gw
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <button id="2qw-EU-T3c">
-                                <rect key="frame" x="20" y="106" width="20" height="20"/>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2qw-EU-T3c">
+                                <rect key="frame" x="20" y="156" width="20" height="20"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="Kot-MX-lmn">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -176,12 +181,12 @@ Gw
                                     <action selector="eyeButtonWasClicked:" target="-2" id="kjC-lx-XUU"/>
                                 </connections>
                             </button>
-                            <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" id="oA3-TX-gWN">
-                                <rect key="frame" x="417" y="226" width="42" height="42"/>
+                            <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oA3-TX-gWN">
+                                <rect key="frame" x="417" y="276" width="42" height="42"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="IEN-Dd-Zla"/>
                             </imageView>
-                            <button id="GtK-TV-ZsK">
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GtK-TV-ZsK">
                                 <rect key="frame" x="18" y="13" width="464" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="check" title="Always show this window$$$" bezelStyle="regularSquare" imagePosition="right" alignment="right" inset="2" id="VsW-uX-oJf">
@@ -190,6 +195,57 @@ Gw
                                 </buttonCell>
                                 <connections>
                                     <outlet property="nextKeyView" destination="9" id="DAr-kx-fVP"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wn3-me-tYT">
+                                <rect key="frame" x="355" y="95" width="129" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="SecurityToken" bezelStyle="regularSquare" imagePosition="right" inset="2" id="SZu-oq-kO8">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="useSecurityTokenCheckboxWasClicked:" target="-2" id="Mi8-Pq-td8"/>
+                                    <outlet property="nextKeyView" destination="adg-1U-zFx" id="7gF-vS-RHz"/>
+                                </connections>
+                            </button>
+                            <secureTextField verticalHuggingPriority="750" id="adg-1U-zFx">
+                                <rect key="frame" x="48" y="93" width="300" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                                <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="xm1-d8-lFy">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <allowedInputSourceLocales>
+                                        <string>NSAllRomanInputSourcesLocaleIdentifier</string>
+                                    </allowedInputSourceLocales>
+                                </secureTextFieldCell>
+                                <connections>
+                                    <outlet property="delegate" destination="-2" id="9na-Wp-cBi"/>
+                                    <outlet property="nextKeyView" destination="Sp5-mN-LXU" id="52I-gB-Jkb"/>
+                                </connections>
+                            </secureTextField>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sp5-mN-LXU">
+                                <rect key="frame" x="48" y="93" width="300" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="on3-qa-2fP">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <outlet property="delegate" destination="-2" id="67N-0n-rpS"/>
+                                </connections>
+                            </textField>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LS4-oh-7b6">
+                                <rect key="frame" x="21" y="93" width="20" height="20"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="Hf1-sU-L1U">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="securityEyeButtonWasClicked:" target="-2" id="jL0-ci-tzU"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/tunnelblick/LoginWindow.xib
+++ b/tunnelblick/LoginWindow.xib
@@ -135,10 +135,10 @@
                                     <outlet property="nextKeyView" destination="TLH-Cp-GnI" id="GRt-CA-kYV"/>
                                 </connections>
                             </button>
-                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dJA-CF-S99">
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dJA-CF-S99" customClass="TBButton">
                                 <rect key="frame" x="17" y="96" width="129" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="check" title="SecurityToken" bezelStyle="regularSquare" imagePosition="left" inset="2" id="eAY-fP-3b3">
+                                <buttonCell key="cell" type="check" title="Token" bezelStyle="regularSquare" imagePosition="left" inset="2" id="eAY-fP-3b3">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>

--- a/tunnelblick/LoginWindow.xib
+++ b/tunnelblick/LoginWindow.xib
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G22010" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="LoginWindowController">
@@ -17,29 +18,33 @@
                 <outlet property="passwordTFC" destination="47" id="51"/>
                 <outlet property="savePasswordInKeychainCheckbox" destination="86" id="90"/>
                 <outlet property="saveUsernameInKeychainCheckbox" destination="42" id="89"/>
+                <outlet property="securityEyeButton" destination="6Lq-A6-Dc6" id="8Lt-1K-jRh"/>
+                <outlet property="securityToken" destination="5xj-ZW-Wvo" id="bTI-32-e0Z"/>
+                <outlet property="useSecurityTokenCheckbox" destination="dJA-CF-S99" id="p2b-zt-Gcr"/>
                 <outlet property="username" destination="38" id="64"/>
                 <outlet property="usernameTFC" destination="45" id="54"/>
                 <outlet property="visiblePassword" destination="d3G-tm-xxA" id="cn9-Bk-bKk"/>
+                <outlet property="visibleSecurityToken" destination="ivD-9F-0bg" id="AtM-XN-xG9"/>
                 <outlet property="window" destination="1" id="15"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" frameAutosaveName="ConnectingWindow" animationBehavior="default" id="1">
+        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="ConnectingWindow" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="345" width="500" height="300"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1028"/>
+            <rect key="contentRect" x="196" y="345" width="500" height="350"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
             <view key="contentView" id="2">
-                <rect key="frame" x="0.0" y="0.0" width="500" height="300"/>
+                <rect key="frame" x="0.0" y="0.0" width="500" height="350"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <customView id="27">
-                        <rect key="frame" x="0.0" y="0.0" width="500" height="300"/>
+                    <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="27">
+                        <rect key="frame" x="0.0" y="0.0" width="500" height="350"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <subviews>
-                            <textField verticalHuggingPriority="750" id="31">
-                                <rect key="frame" x="109" y="208" width="373" height="76"/>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="31">
+                                <rect key="frame" x="109" y="258" width="373" height="76"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="text" id="32">
                                     <font key="font" metaFont="system"/>
@@ -47,8 +52,8 @@
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" id="44" userLabel="Username label">
-                                <rect key="frame" x="17" y="178" width="129" height="17"/>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="44" userLabel="Username label">
+                                <rect key="frame" x="17" y="228" width="129" height="17"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="UsernameLabel" id="45">
                                     <font key="font" metaFont="system"/>
@@ -56,12 +61,12 @@
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" id="38">
-                                <rect key="frame" x="152" y="175" width="328" height="22"/>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="38">
+                                <rect key="frame" x="152" y="225" width="328" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="39">
                                     <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                                 <connections>
@@ -69,8 +74,8 @@
                                     <outlet property="nextKeyView" destination="55" id="102"/>
                                 </connections>
                             </textField>
-                            <button id="42">
-                                <rect key="frame" x="150" y="151" width="333" height="18"/>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="42">
+                                <rect key="frame" x="150" y="201" width="333" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="check" title="Save username in Keychain" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="43">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -78,11 +83,11 @@
                                 </buttonCell>
                                 <connections>
                                     <action selector="saveUsernameInKeychainCheckboxWasClicked:" target="-2" id="91"/>
-                                    <outlet property="nextKeyView" destination="86" id="104"/>
+                                    <outlet property="nextKeyView" destination="86" id="DK0-Xr-Bdu"/>
                                 </connections>
                             </button>
-                            <textField verticalHuggingPriority="750" id="46" userLabel="Password label">
-                                <rect key="frame" x="17" y="114" width="129" height="17"/>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="46" userLabel="Password label">
+                                <rect key="frame" x="17" y="164" width="129" height="17"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="PasswordLabel" id="47">
                                     <font key="font" metaFont="system"/>
@@ -90,12 +95,12 @@
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <secureTextField verticalHuggingPriority="750" id="55">
-                                <rect key="frame" x="152" y="111" width="300" height="22"/>
+                            <secureTextField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="55">
+                                <rect key="frame" x="152" y="161" width="300" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="56">
                                     <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <allowedInputSourceLocales>
                                         <string>NSAllRomanInputSourcesLocaleIdentifier</string>
@@ -103,34 +108,75 @@
                                 </secureTextFieldCell>
                                 <connections>
                                     <outlet property="delegate" destination="-2" id="62"/>
-                                    <outlet property="nextKeyView" destination="42" id="YMm-IW-6cN"/>
+                                    <outlet property="nextKeyView" destination="d3G-tm-xxA" id="BuF-Vl-ndq"/>
                                 </connections>
                             </secureTextField>
-                            <textField verticalHuggingPriority="750" id="d3G-tm-xxA">
-                                <rect key="frame" x="152" y="111" width="300" height="22"/>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d3G-tm-xxA">
+                                <rect key="frame" x="152" y="161" width="300" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="M3Y-1v-I6A">
                                     <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                                 <connections>
                                     <outlet property="delegate" destination="-2" id="0Ca-CO-ANC"/>
-                                    <outlet property="nextKeyView" destination="42" id="Cpe-rl-WjP"/>
+                                    <outlet property="nextKeyView" destination="dJA-CF-S99" id="TF1-T6-eac"/>
                                 </connections>
                             </textField>
-                            <button id="86">
-                                <rect key="frame" x="150" y="87" width="332" height="18"/>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="86">
+                                <rect key="frame" x="150" y="137" width="332" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="check" title="Save password in Keychain" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="87">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <outlet property="nextKeyView" destination="9" id="Ss3-St-Zpg"/>
+                                    <outlet property="nextKeyView" destination="TLH-Cp-GnI" id="GRt-CA-kYV"/>
                                 </connections>
                             </button>
-                            <button verticalHuggingPriority="750" id="9">
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dJA-CF-S99">
+                                <rect key="frame" x="17" y="96" width="129" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="SecurityToken" bezelStyle="regularSquare" imagePosition="left" inset="2" id="eAY-fP-3b3">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="useSecurityTokenCheckboxWasClicked:" target="-2" id="NXJ-fp-E7U"/>
+                                    <outlet property="nextKeyView" destination="5xj-ZW-Wvo" id="61f-94-5bw"/>
+                                </connections>
+                            </button>
+                            <secureTextField verticalHuggingPriority="750" id="5xj-ZW-Wvo">
+                                <rect key="frame" x="151" y="94" width="300" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                                <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="GjD-Eh-ljU">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <allowedInputSourceLocales>
+                                        <string>NSAllRomanInputSourcesLocaleIdentifier</string>
+                                    </allowedInputSourceLocales>
+                                </secureTextFieldCell>
+                                <connections>
+                                    <outlet property="delegate" destination="-2" id="gh4-OB-2FS"/>
+                                    <outlet property="nextKeyView" destination="ivD-9F-0bg" id="EJ6-gA-XHt"/>
+                                </connections>
+                            </secureTextField>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ivD-9F-0bg">
+                                <rect key="frame" x="151" y="94" width="300" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="aWH-g5-90R">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <outlet property="delegate" destination="-2" id="GPj-AT-MV8"/>
+                                    <outlet property="nextKeyView" destination="42" id="W8s-yD-2A7"/>
+                                </connections>
+                            </textField>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9">
                                 <rect key="frame" x="381" y="41" width="105" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="push" title="O" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="10">
@@ -145,7 +191,7 @@ DQ
                                     <outlet property="nextKeyView" destination="35" id="108"/>
                                 </connections>
                             </button>
-                            <button id="TLH-Cp-GnI" userLabel="Always show this window Checkbox">
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TLH-Cp-GnI" userLabel="Always show this window Checkbox">
                                 <rect key="frame" x="19" y="18" width="464" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="check" title="Always show this window$$$" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="jtk-B7-hT4">
@@ -156,8 +202,8 @@ DQ
                                     <outlet property="nextKeyView" destination="38" id="O0L-qN-jLE"/>
                                 </connections>
                             </button>
-                            <button id="PCd-3S-bP7">
-                                <rect key="frame" x="460" y="112" width="20" height="20"/>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PCd-3S-bP7">
+                                <rect key="frame" x="460" y="162" width="20" height="20"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="8Fd-wU-leU">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -167,12 +213,23 @@ DQ
                                     <action selector="eyeButtonWasClicked:" target="-2" id="7a1-eR-vCH"/>
                                 </connections>
                             </button>
-                            <imageView id="3">
-                                <rect key="frame" x="21" y="212" width="72" height="72"/>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Lq-A6-Dc6">
+                                <rect key="frame" x="460" y="95" width="20" height="20"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="Uu3-Ai-eBa">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="securityEyeButtonWasClicked:" target="-2" id="hI3-1d-9Rx"/>
+                                </connections>
+                            </button>
+                            <imageView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3">
+                                <rect key="frame" x="21" y="262" width="72" height="72"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="4"/>
                             </imageView>
-                            <button verticalHuggingPriority="750" id="35">
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="35">
                                 <rect key="frame" x="265" y="41" width="105" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="push" title="C" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="36">
@@ -198,7 +255,7 @@ Gw
                 <outlet property="delegate" destination="-2" id="24"/>
                 <outlet property="initialFirstResponder" destination="38" id="77"/>
             </connections>
-            <point key="canvasLocation" x="655" y="399"/>
+            <point key="canvasLocation" x="655" y="424"/>
         </window>
     </objects>
 </document>

--- a/tunnelblick/LoginWindowController.h
+++ b/tunnelblick/LoginWindowController.h
@@ -34,18 +34,18 @@
     IBOutlet NSSecureTextField  * password;
     IBOutlet NSTextField        * visiblePassword;
     IBOutlet NSSecureTextField  * securityToken;
-	  IBOutlet NSTextField				* visibleSecurityToken;
+    IBOutlet NSTextField        * visibleSecurityToken;
 
     IBOutlet NSTextFieldCell    * usernameTFC;
     IBOutlet NSTextFieldCell    * passwordTFC;
 
     IBOutlet NSButton           * eyeButton;
-		IBOutlet NSButton           * securityEyeButton;
+    IBOutlet NSButton           * securityEyeButton;
 
     IBOutlet NSButton           * saveUsernameInKeychainCheckbox;
     IBOutlet NSButton           * savePasswordInKeychainCheckbox;
-  	IBOutlet NSButton           * useSecurityTokenCheckbox;
-	  IBOutlet NSButton           * alwaysShowLoginWindowCheckbox;
+    IBOutlet NSButton           * useSecurityTokenCheckbox;
+    IBOutlet NSButton           * alwaysShowLoginWindowCheckbox;
 
     id                            delegate;
 

--- a/tunnelblick/LoginWindowController.h
+++ b/tunnelblick/LoginWindowController.h
@@ -33,15 +33,19 @@
     IBOutlet NSTextField        * username;
     IBOutlet NSSecureTextField  * password;
     IBOutlet NSTextField        * visiblePassword;
+    IBOutlet NSSecureTextField  * securityToken;
+	  IBOutlet NSTextField				* visibleSecurityToken;
 
     IBOutlet NSTextFieldCell    * usernameTFC;
     IBOutlet NSTextFieldCell    * passwordTFC;
 
     IBOutlet NSButton           * eyeButton;
-    
+		IBOutlet NSButton           * securityEyeButton;
+
     IBOutlet NSButton           * saveUsernameInKeychainCheckbox;
     IBOutlet NSButton           * savePasswordInKeychainCheckbox;
-	IBOutlet NSButton           * alwaysShowLoginWindowCheckbox;
+  	IBOutlet NSButton           * useSecurityTokenCheckbox;
+	  IBOutlet NSButton           * alwaysShowLoginWindowCheckbox;
 
     id                            delegate;
 
@@ -55,15 +59,19 @@
 -(IBAction) cancelButtonWasClicked: (id)            sender;
 -(IBAction) OKButtonWasClicked:     (id)            sender;
 -(IBAction) eyeButtonWasClicked:    (id)            sender;
+-(IBAction) securityEyeButtonWasClicked:    (id)            sender;
 
 -(IBAction) saveUsernameInKeychainCheckboxWasClicked: (id) sender;
+-(IBAction) useSecurityTokenCheckboxWasClicked: (id) sender;
 
 -(BOOL)     isSaveUsernameInKeychainChecked;
 -(BOOL)     isSavePasswordInKeychainChecked;
+-(BOOL)     useSecurityTokenChecked;
 
 TBPROPERTY_READONLY(NSTextField *,       username)
 TBPROPERTY_READONLY(NSSecureTextField *, password)
 TBPROPERTY_READONLY(NSTextField *,       visiblePassword)
+TBPROPERTY_READONLY(NSTextField *,       securityToken)
 
 TBPROPERTY_READONLY(NSButton *,    eyeButton)
 

--- a/tunnelblick/LoginWindowController.h
+++ b/tunnelblick/LoginWindowController.h
@@ -20,6 +20,7 @@
  */
 
 #include "defines.h"
+#import "TBButton.h"
 
 @interface LoginWindowController : NSWindowController <NSWindowDelegate>
 {
@@ -44,7 +45,7 @@
 
     IBOutlet NSButton           * saveUsernameInKeychainCheckbox;
     IBOutlet NSButton           * savePasswordInKeychainCheckbox;
-    IBOutlet NSButton           * useSecurityTokenCheckbox;
+    IBOutlet TBButton           * useSecurityTokenCheckbox;
     IBOutlet NSButton           * alwaysShowLoginWindowCheckbox;
 
     id                            delegate;

--- a/tunnelblick/LoginWindowController.m
+++ b/tunnelblick/LoginWindowController.m
@@ -220,19 +220,20 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSImage *, eyeRedSlash)
 
     const char * usernameC = [escaped(  [[self username] stringValue]  ) UTF8String];
     const char * passwordC = [escaped(  [[self password] stringValue]  ) UTF8String];
-    const char * securityTockenC = [self useSecurityTokenChecked] ?
+    const char * securityTokenC = [self useSecurityTokenChecked] ?
 			[escaped(  [[self securityToken] stringValue]  ) UTF8String] : "";
 
     if (   (strlen(usernameC) == 0)
         || (strlen(usernameC) > MAX_LENGTH_OF_QUOTED_MANGEMENT_INTERFACE_PARAMETER)
-        || ((strlen(passwordC) + strlen(securityTockenC)) > MAX_LENGTH_OF_QUOTED_MANGEMENT_INTERFACE_PARAMETER)
-				|| ([self useSecurityTokenChecked] && strlen(securityTockenC) == 0)) {
+        || ((strlen(passwordC) + strlen(securityTokenC)) > MAX_LENGTH_OF_QUOTED_MANGEMENT_INTERFACE_PARAMETER)
+				|| ([self useSecurityTokenChecked] && strlen(securityTokenC) == 0)) {
         [UIHelper shakeWindow: self.window];
         return;
     }
 
 	NSString * key = [[delegate displayName] stringByAppendingString: @"-alwaysShowLoginWindow"];
 	[gTbDefaults setBool: [self isAlwaysShowLoginWindowChecked] forKey: key];
+	
 	key = [[delegate displayName] stringByAppendingString: @"-useSecurityToken"];
 	[gTbDefaults setBool: [self useSecurityTokenChecked] forKey: key];
 
@@ -336,13 +337,13 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSImage *, eyeRedSlash)
 
 		if (  [[securityEyeButton image] isEqual: eyeNormal]  ) {
 
-				// Make password visible and swap the eye image
+				// Make token visible and swap the eye image
 				NSString * token = [[self securityToken] stringValue];
 				[self setInputBoxAndSecurityToken: token exposed: YES];
 
 		} else {
 
-				// Make password invisible and swap the eye image
+				// Make token invisible and swap the eye image
 				NSString * token = [[self visibleSecurityToken] stringValue];
         [self setInputBoxAndSecurityToken: token exposed: NO];
 		}

--- a/tunnelblick/LoginWindowController.m
+++ b/tunnelblick/LoginWindowController.m
@@ -43,7 +43,7 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSTextField       *, visibleSecurityToken)
 
 TBSYNTHESIZE_OBJECT_GET(retain, NSButton *, saveUsernameInKeychainCheckbox)
 TBSYNTHESIZE_OBJECT_GET(retain, NSButton *, savePasswordInKeychainCheckbox)
-TBSYNTHESIZE_OBJECT_GET(retain, NSButton *, useSecurityTokenCheckbox)
+TBSYNTHESIZE_OBJECT_GET(retain, TBButton *, useSecurityTokenCheckbox)
 TBSYNTHESIZE_OBJECT_GET(retain, NSButton *, alwaysShowLoginWindowCheckbox)
 
 TBSYNTHESIZE_OBJECT_GET(retain, NSButton *, eyeButton)
@@ -110,7 +110,11 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSImage *, eyeRedSlash)
 
     [saveUsernameInKeychainCheckbox setTitle: NSLocalizedString(@"Save in Keychain",        @"Checkbox name")];
     [savePasswordInKeychainCheckbox setTitle: NSLocalizedString(@"Save in Keychain",        @"Checkbox name")];
-    [useSecurityTokenCheckbox setTitle: NSLocalizedString(@"Security Token",            		@"Checkbox name")];
+    [useSecurityTokenCheckbox setTitle: NSLocalizedString(@"Token", @"Checkbox name")
+														 infoTitle: attributedStringFromHTML(NSLocalizedString(
+																												  @"<p>Allows for the additional entry of a security token when checked.</p>\n"
+																												  @"<p>This token is appended to the password during the authentication process. This enables the simultaneous use of authentication devices (dongels) together with the the keychain to secure the password.</p>\n",
+																												  @"HTML Info for security token checkbox"))];
 	  [alwaysShowLoginWindowCheckbox  setTitle: NSLocalizedString(@"Always show this window", @"Checkbox name")];
 
     [savePasswordInKeychainCheckbox setState:   NSOffState];
@@ -180,9 +184,12 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSImage *, eyeRedSlash)
 													 : NSOffState)];
 	[[self alwaysShowLoginWindowCheckbox] setEnabled: TRUE];
 	
-	key = [[delegate displayName] stringByAppendingString: @"-useSecurityToken"];
+	key = [[delegate displayName] stringByAppendingString: @"-loginWindowSecurityTokenCheckboxIsChecked"];
 	[[self useSecurityTokenCheckbox] setState:( [gTbDefaults boolForKey:key] ? NSOnState : NSOffState)];
 	[[self securityToken] setEnabled:[gTbDefaults boolForKey:key]];
+	[[self visibleSecurityToken] setEnabled:[gTbDefaults boolForKey:key]];
+	[[self securityEyeButton] setEnabled:[gTbDefaults boolForKey:key]];
+	[[self securityEyeButton] setHidden:![gTbDefaults boolForKey:key]];
 	[self setInputBoxAndSecurityToken:@"" exposed: FALSE];
 
     [cancelButton setEnabled: YES];
@@ -234,7 +241,7 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSImage *, eyeRedSlash)
 	NSString * key = [[delegate displayName] stringByAppendingString: @"-alwaysShowLoginWindow"];
 	[gTbDefaults setBool: [self isAlwaysShowLoginWindowChecked] forKey: key];
 	
-	key = [[delegate displayName] stringByAppendingString: @"-useSecurityToken"];
+	key = [[delegate displayName] stringByAppendingString: @"-loginWindowSecurityTokenCheckboxIsChecked"];
 	[gTbDefaults setBool: [self useSecurityTokenChecked] forKey: key];
 
     [cancelButton setEnabled: NO];
@@ -258,9 +265,14 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSImage *, eyeRedSlash)
 
 -(IBAction) useSecurityTokenCheckboxWasClicked: (id) sender {
     (void) sender;
+    BOOL isEnabled = [useSecurityTokenCheckbox state] == NSOnState;
 
-    [securityToken setEnabled:[useSecurityTokenCheckbox state] == NSOnState];
+    [securityToken setEnabled:isEnabled];
+    [visibleSecurityToken setEnabled:isEnabled];
+    [securityEyeButton setEnabled:isEnabled];
+    [securityEyeButton setHidden:!isEnabled];
     [[self securityToken] setStringValue:@""];
+    [[self visibleSecurityToken] setStringValue:@""];
 }
 
 -(void) exposePasswordAndSetImage {


### PR DESCRIPTION
- Added a checkbox, input fields and a switch for visibility to the login window
- The input fields are for entering security tokens (e.g. YubiKey) without changing the password.
- This allows the use of security tokens together with passwords from the keychain.
- The password for openvpn is simply created by appending the security token to the password.
