### PR TITLE
Show login window on all spaces

### DIFF
--- a/tunnelblick/LoginWindowController.m
+++ b/tunnelblick/LoginWindowController.m
@@ -204,6 +204,7 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSImage *, eyeRedSlash)
     [cancelButton setEnabled: YES];
     [OKButton setEnabled: YES];
     [[self window] center];
+    [[self window] setCollectionBehavior: NSWindowCollectionBehaviorCanJoinAllSpaces|NSWindowCollectionBehaviorFullScreenAuxiliary];
     [[self window] display];
     [self showWindow: self];
     [gMC activateIgnoringOtherApps];


### PR DESCRIPTION
I am always searching for the login window when I resume after a pause..
With this little patch it will appear on all spaces, even on top of fullscreen apps.