### PR TITLE
Support native macOS IOUserEthernet devices for TAP

### DIFF
--- a/third_party/makefiles/Makefile-openvpn
+++ b/third_party/makefiles/Makefile-openvpn
@@ -34,6 +34,7 @@ built-openvpn-prepare:
 		openvpn_name="$${openvpn_tar_name%.*}" ; \
 		mv $$openvpn_name   openvpn ; \
 		cd  openvpn ; \
+		curl -o IOUserEthernetController.h https://opensource.apple.com/source/IOKitUser/IOKitUser-1845.120.6/network.subproj/IOUserEthernetController.h; \
 		if [ -d $(OPENVPN_SOURCE_DIR)/$$openvpn_folder_name/patches ]; then \
 			for patch_file in $$(ls $(OPENVPN_SOURCE_DIR)/$$openvpn_folder_name/patches/*.diff); do \
 				patch_name=$$(basename "$${patch_file}") ; \
@@ -125,7 +126,7 @@ built-openvpn: built-openvpn-prepare built-lzo built-lz4 built-pkcs11-helper bui
                             \
                             if [ -n "$$pkcs11_enable" ] ; then \
                                 CC="$(CC)" \
-                                    CFLAGS="$(CFLAGS) -arch $$a $(OPENVPN_DEPRECATED_LLVN_OPTION) -D __APPLE_USE_RFC_3542" \
+                                    CFLAGS="$(CFLAGS) -I. -arch $$a $(OPENVPN_DEPRECATED_LLVN_OPTION) -D __APPLE_USE_RFC_3542" \
                                     LZO_CFLAGS="-I$(LZO_STAGING_DIR)_$$a/include" \
                                     LZO_LIBS="-L$(LZO_STAGING_DIR)_$$a/lib -llzo2" \
                                     LZ4_CFLAGS="-I$(LZ4_STAGING_DIR)_$$a/include" \

--- a/third_party/sources/openvpn/openvpn-2.4.11/patches/07-apple-iouserethernet.diff
+++ b/third_party/sources/openvpn/openvpn-2.4.11/patches/07-apple-iouserethernet.diff
@@ -43,10 +43,10 @@ index 9c898718..2a9a04ad 100644
  	*-mingw*)
  		AC_DEFINE([TARGET_WIN32], [1], [Are we running WIN32?])
 diff --git a/src/openvpn/tun.c b/src/openvpn/tun.c
-index 9b6d8d68..0e6b923d 100644
+index 9b6d8d68..3ba371ec 100644
 --- a/src/openvpn/tun.c
 +++ b/src/openvpn/tun.c
-@@ -56,6 +56,145 @@
+@@ -56,6 +56,150 @@
  
  #include <string.h>
  
@@ -97,6 +97,8 @@ index 9b6d8d68..0e6b923d 100644
 +            found = true;
 +        }
 +    }
++    CFRelease(ifCFName);
++    CFRelease(sc);
 +    CFRelease(services);
 +    return found;
 +}
@@ -128,13 +130,16 @@ index 9b6d8d68..0e6b923d 100644
 +    char *buffer = (char *)malloc(maxSize);
 +    if (buffer == NULL) {
 +        msg(M_ERR, "ERROR: Unable to malloc space for BSD interface name");
++        CFRelease(bsdName);
 +        return NULL;
 +    }
 +    if (!CFStringGetCString(bsdName, buffer, maxSize, kCFStringEncodingUTF8)) {
 +        msg(M_ERR, "ERROR: Unable to convert bsdName to cstring");
++        CFRelease(bsdName);
 +        free(buffer);
 +        return NULL;
 +    }
++    CFRelease(bsdName);
 +    return buffer;
 +}
 +
@@ -192,7 +197,7 @@ index 9b6d8d68..0e6b923d 100644
  #ifdef _WIN32
  
  const static GUID GUID_DEVCLASS_NET = { 0x4d36e972L, 0xe325, 0x11ce, { 0xbf, 0xc1, 0x08, 0x00, 0x2b, 0xe1, 0x03, 0x18 } };
-@@ -1789,7 +1928,36 @@ open_tun_generic(const char *dev, const char *dev_type, const char *dev_node,
+@@ -1789,7 +1933,36 @@ open_tun_generic(const char *dev, const char *dev_type, const char *dev_node,
                  }
                  if (!dynamic_opened)
                  {

--- a/third_party/sources/openvpn/openvpn-2.4.11/patches/07-apple-iouserethernet.diff
+++ b/third_party/sources/openvpn/openvpn-2.4.11/patches/07-apple-iouserethernet.diff
@@ -1,0 +1,231 @@
+diff --git a/README.apple b/README.apple
+new file mode 100644
+index 00000000..d611d261
+--- /dev/null
++++ b/README.apple
+@@ -0,0 +1,12 @@
++To compile TAP support for new Apple OS, IOKit IOUserEthernetController headers are required:
++
++mkdir -p appleinclude/IOKit/network
++curl -o appleinclude/IOKit/network/IOUserEthernetController.h https://opensource.apple.com/source/IOKitUser/IOKitUser-1845.120.6/network.subproj/IOUserEthernetController.h
++
++Add IOKitUser/network.subproj to include search path and link CoreFoundation and IOKit
++
++	CFLAGS="-I$(pwd)/appleinclude" ./configure
++	make
++	make install
++
++OpenVPN will now create a new en interface and use that as it previously used a TAP interface
+diff --git a/configure.ac b/configure.ac
+index 9c898718..2a9a04ad 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -317,7 +317,21 @@ case "$host" in
+ 		AC_DEFINE([TARGET_DARWIN], [1], [Are we running on Mac OS X?])
+ 		AC_DEFINE_UNQUOTED([TARGET_PREFIX], ["M"], [Target prefix])
+ 		have_tap_header="yes"
++		AC_CHECK_HEADER(
++			[IOKit/network/IOUserEthernetController.h],
++			[
++			 have_ioethernet_header="yes"
++			 AC_DEFINE([DARWIN_IOKIT_FULL_PATH], [1], [Include <IOKit/network/IOUserEthernetController.h>])
++			],
++			[
++			  AC_CHECK_HEADER([IOUserEthernetController.h], [have_ioethernet_header="yes"], [], [])
++			],
++			[]
++		)
++		test "${have_ioethernet_header}" = "yes" || AC_MSG_ERROR([no IOUserEthernetController header could be found])
++
+ 		ac_cv_type_struct_in_pktinfo=no
++		LDFLAGS="${LDFLAGS} -framework CoreFoundation -framework IOKit -framework SystemConfiguration"
+ 		;;
+ 	*-mingw*)
+ 		AC_DEFINE([TARGET_WIN32], [1], [Are we running WIN32?])
+diff --git a/src/openvpn/tun.c b/src/openvpn/tun.c
+index 9b6d8d68..0e6b923d 100644
+--- a/src/openvpn/tun.c
++++ b/src/openvpn/tun.c
+@@ -56,6 +56,145 @@
+ 
+ #include <string.h>
+ 
++#if TARGET_DARWIN
++#include <IOKit/IOBSD.h>
++#include <IOKit/IOKitLib.h>
++#include <IOKit/network/IONetworkController.h>
++#include <SystemConfiguration/SystemConfiguration.h>
++#include <net/ethernet.h>
++#if DARWIN_IOKIT_FULL_PATH
++#include <IOKit/network/IOUserEthernetController.h>
++#else
++#include <IOUserEthernetController.h>
++#endif
++#include <IOKit/storage/IOStorageDeviceCharacteristics.h>
++
++#include <CoreFoundation/CoreFoundation.h>
++#include <unistd.h>
++extern int IOEthernetControllerGetBSDSocket(IOEthernetControllerRef controller);
++extern io_object_t IOEthernetControllerGetIONetworkInterfaceObject(IOEthernetControllerRef controller);
++
++static IOEthernetControllerRef newController;
++
++kern_return_t
++IORegistryEntryGetProperty(
++    io_registry_entry_t   entry,
++    const io_name_t       propertyName,
++    io_struct_inband_t    buffer,
++    uint32_t            * size );
++
++static bool
++disable_dhcp_services(const char *ifName)
++{
++
++    SCPreferencesRef sc = SCPreferencesCreate(NULL, CFSTR("openvpn"), NULL);
++    CFArrayRef services = SCNetworkServiceCopyAll(sc);
++    CFIndex numKeys = CFArrayGetCount(services);
++    const CFStringRef ifCFName = CFStringCreateWithCString(NULL, ifName, kCFStringEncodingASCII);
++    bool found = false;
++
++    for (CFIndex i=0; i<numKeys; i++) {
++        SCNetworkServiceRef netSvc = CFArrayGetValueAtIndex(services, i);
++        SCNetworkInterfaceRef scInterface = SCNetworkServiceGetInterface(netSvc);
++        CFStringRef bsdName = SCNetworkInterfaceGetBSDName(scInterface);
++        if (bsdName != NULL && CFStringCompare(ifCFName, bsdName, 0) == 0) {
++            // Disables this OSX managed service but does not disable the interface
++            SCNetworkServiceSetEnabled(netSvc, false);
++            found = true;
++        }
++    }
++    CFRelease(services);
++    return found;
++}
++
++static char *
++copy_interface_name(IOEthernetControllerRef controller)
++{
++    CFStringRef     bsdName;
++    io_object_t     interface;
++
++    interface = IOEthernetControllerGetIONetworkInterfaceObject(controller);
++    if (interface == MACH_PORT_NULL) {
++        msg(M_ERR, "ERROR: could not get IO interface for IOEthernetController");
++        return NULL;
++    }
++
++    // It can take a bit for the interface to register
++    for (int i=0; i<10; i++) {
++        bsdName = IORegistryEntryCreateCFProperty(interface, CFSTR(kIOBSDNameKey), NULL, kNilOptions);
++        if (bsdName != NULL) break;
++        usleep(10000);
++    }
++    if (bsdName == NULL) {
++        msg(M_ERR, "ERROR: IOEthernetController with no BSD interface name");
++        return NULL;
++    }
++    CFIndex length = CFStringGetLength(bsdName);
++    CFIndex maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
++    char *buffer = (char *)malloc(maxSize);
++    if (buffer == NULL) {
++        msg(M_ERR, "ERROR: Unable to malloc space for BSD interface name");
++        return NULL;
++    }
++    if (!CFStringGetCString(bsdName, buffer, maxSize, kCFStringEncodingUTF8)) {
++        msg(M_ERR, "ERROR: Unable to convert bsdName to cstring");
++        free(buffer);
++        return NULL;
++    }
++    return buffer;
++}
++
++static struct ether_addr generate_random_mac(void) {
++    uint32_t rand1 = arc4random();
++    uint32_t rand2 = arc4random();
++    struct ether_addr rea = {.octet = {
++                                 (rand1 >> 0) & 0xff,
++                                 (rand1 >> 8) & 0xff,
++                                 (rand1 >> 16) & 0xff,
++                                 (rand1 >> 24) & 0xff,
++                                 (rand2 >> 0) & 0xff,
++                                 (rand2 >> 8) & 0xff,
++                             }};
++    rea.octet[0] |= 0x02;
++    rea.octet[0] &= 0xfe;
++    return rea;
++}
++
++#define    kSCNetworkInterfaceHiddenConfigurationKey        CFSTR("HiddenConfiguration")
++static IOEthernetControllerRef
++create_user_interface()
++{
++    CFMutableDictionaryRef mergeProperties, props;
++    IOEthernetControllerRef controller;
++    CFDataRef data;
++    struct ether_addr ea;
++
++    ea = generate_random_mac();
++
++    props = CFDictionaryCreateMutable(NULL, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
++    data = CFDataCreate(NULL, ea.octet, ETHER_ADDR_LEN);
++    CFDictionarySetValue(props, kIOEthernetHardwareAddress, data);
++    CFRelease(data);
++
++    mergeProperties = CFDictionaryCreateMutable(NULL, 3, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
++    CFDictionarySetValue(mergeProperties, CFSTR(kIOPropertyProductNameKey), CFSTR("OpenVPN TAP Ethernet"));
++    CFDictionarySetValue(mergeProperties, kIOUserEthernetInterfaceRole, CFSTR("hidden-ethernet"));
++    CFDictionarySetValue(mergeProperties, kSCNetworkInterfaceHiddenConfigurationKey, kCFBooleanTrue);
++    CFDictionarySetValue(props, kIOUserEthernetInterfaceMergeProperties, mergeProperties);
++    CFRelease(mergeProperties);
++
++    controller = IOEthernetControllerCreate(NULL, props);
++    CFRelease(props);
++    if (controller == NULL) {
++        msg(M_ERR, "ERROR: could not create ethernet controller for \"%s\"", ether_ntoa(&ea));
++        return NULL;
++    }
++
++    return controller;
++}
++
++#endif // TARGET_DARWIN
++
+ #ifdef _WIN32
+ 
+ const static GUID GUID_DEVCLASS_NET = { 0x4d36e972L, 0xe325, 0x11ce, { 0xbf, 0xc1, 0x08, 0x00, 0x2b, 0xe1, 0x03, 0x18 } };
+@@ -1789,7 +1928,36 @@ open_tun_generic(const char *dev, const char *dev_type, const char *dev_node,
+                 }
+                 if (!dynamic_opened)
+                 {
++#if TARGET_DARWIN
++                    char    *bsdName;
++                    msg(M_INFO, "Cannot allocate TUN/TAP dev dynamically");
++                    newController = create_user_interface();
++                    if (newController == NULL) {
++                        msg(M_FATAL, "ERROR: could not create controller");
++                        return;
++                    }
++
++                    IOEthernetControllerSetLinkStatus(newController, 1);
++                    tt->fd = IOEthernetControllerGetBSDSocket(newController);
++                    if (tt->fd == -1) {
++                        msg(M_FATAL, "ERROR: Unable to get BSD Socket for IOEthernetController");
++                    }
++                    dynamic_opened = true;
++                    bsdName = copy_interface_name(newController);
++                    if (bsdName == NULL) {
++                        msg(M_FATAL, "ERROR: no bsd name\n");
++                        return;
++                    }
++                    msg(M_INFO, "Got bsdname : %s\n", bsdName);
++                    strcpy(dynamic_name, bsdName);
++                    free(bsdName);
++                    msg(M_INFO, "Got name : %s\n", dynamic_name);
++                    if (!disable_dhcp_services(dynamic_name)) {
++                        msg(M_FATAL, "ERROR: Could not disable macOS services on %s", dynamic_name);
++                    }
++#else
+                     msg(M_FATAL, "Cannot allocate TUN/TAP dev dynamically");
++#endif
+                 }
+             }
+             /*

--- a/third_party/sources/openvpn/openvpn-2.5.5/patches/11-apple-iouserethernet.diff
+++ b/third_party/sources/openvpn/openvpn-2.5.5/patches/11-apple-iouserethernet.diff
@@ -43,10 +43,10 @@ index 9c898718..2a9a04ad 100644
  	*-mingw*)
  		AC_DEFINE([TARGET_WIN32], [1], [Are we running WIN32?])
 diff --git a/src/openvpn/tun.c b/src/openvpn/tun.c
-index 9b6d8d68..0e6b923d 100644
+index 9b6d8d68..3ba371ec 100644
 --- a/src/openvpn/tun.c
 +++ b/src/openvpn/tun.c
-@@ -56,6 +56,145 @@
+@@ -56,6 +56,150 @@
  
  #include <string.h>
  
@@ -97,6 +97,8 @@ index 9b6d8d68..0e6b923d 100644
 +            found = true;
 +        }
 +    }
++    CFRelease(ifCFName);
++    CFRelease(sc);
 +    CFRelease(services);
 +    return found;
 +}
@@ -128,13 +130,16 @@ index 9b6d8d68..0e6b923d 100644
 +    char *buffer = (char *)malloc(maxSize);
 +    if (buffer == NULL) {
 +        msg(M_ERR, "ERROR: Unable to malloc space for BSD interface name");
++        CFRelease(bsdName);
 +        return NULL;
 +    }
 +    if (!CFStringGetCString(bsdName, buffer, maxSize, kCFStringEncodingUTF8)) {
 +        msg(M_ERR, "ERROR: Unable to convert bsdName to cstring");
++        CFRelease(bsdName);
 +        free(buffer);
 +        return NULL;
 +    }
++    CFRelease(bsdName);
 +    return buffer;
 +}
 +
@@ -192,7 +197,7 @@ index 9b6d8d68..0e6b923d 100644
  #ifdef _WIN32
  
  const static GUID GUID_DEVCLASS_NET = { 0x4d36e972L, 0xe325, 0x11ce, { 0xbf, 0xc1, 0x08, 0x00, 0x2b, 0xe1, 0x03, 0x18 } };
-@@ -1789,7 +1928,36 @@ open_tun_generic(const char *dev, const char *dev_type, const char *dev_node,
+@@ -1789,7 +1933,36 @@ open_tun_generic(const char *dev, const char *dev_type, const char *dev_node,
                  }
                  if (!dynamic_opened)
                  {

--- a/third_party/sources/openvpn/openvpn-2.5.5/patches/11-apple-iouserethernet.diff
+++ b/third_party/sources/openvpn/openvpn-2.5.5/patches/11-apple-iouserethernet.diff
@@ -1,0 +1,231 @@
+diff --git a/README.apple b/README.apple
+new file mode 100644
+index 00000000..d611d261
+--- /dev/null
++++ b/README.apple
+@@ -0,0 +1,12 @@
++To compile TAP support for new Apple OS, IOKit IOUserEthernetController headers are required:
++
++mkdir -p appleinclude/IOKit/network
++curl -o appleinclude/IOKit/network/IOUserEthernetController.h https://opensource.apple.com/source/IOKitUser/IOKitUser-1845.120.6/network.subproj/IOUserEthernetController.h
++
++Add IOKitUser/network.subproj to include search path and link CoreFoundation and IOKit
++
++	CFLAGS="-I$(pwd)/appleinclude" ./configure
++	make
++	make install
++
++OpenVPN will now create a new en interface and use that as it previously used a TAP interface
+diff --git a/configure.ac b/configure.ac
+index 9c898718..2a9a04ad 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -317,7 +317,21 @@ case "$host" in
+ 		AC_DEFINE([TARGET_DARWIN], [1], [Are we running on Mac OS X?])
+ 		AC_DEFINE_UNQUOTED([TARGET_PREFIX], ["M"], [Target prefix])
+ 		have_tap_header="yes"
++		AC_CHECK_HEADER(
++			[IOKit/network/IOUserEthernetController.h],
++			[
++			 have_ioethernet_header="yes"
++			 AC_DEFINE([DARWIN_IOKIT_FULL_PATH], [1], [Include <IOKit/network/IOUserEthernetController.h>])
++			],
++			[
++			  AC_CHECK_HEADER([IOUserEthernetController.h], [have_ioethernet_header="yes"], [], [])
++			],
++			[]
++		)
++		test "${have_ioethernet_header}" = "yes" || AC_MSG_ERROR([no IOUserEthernetController header could be found])
++
+ 		ac_cv_type_struct_in_pktinfo=no
++		LDFLAGS="${LDFLAGS} -framework CoreFoundation -framework IOKit -framework SystemConfiguration"
+ 		;;
+ 	*-mingw*)
+ 		AC_DEFINE([TARGET_WIN32], [1], [Are we running WIN32?])
+diff --git a/src/openvpn/tun.c b/src/openvpn/tun.c
+index 9b6d8d68..0e6b923d 100644
+--- a/src/openvpn/tun.c
++++ b/src/openvpn/tun.c
+@@ -56,6 +56,145 @@
+ 
+ #include <string.h>
+ 
++#if TARGET_DARWIN
++#include <IOKit/IOBSD.h>
++#include <IOKit/IOKitLib.h>
++#include <IOKit/network/IONetworkController.h>
++#include <SystemConfiguration/SystemConfiguration.h>
++#include <net/ethernet.h>
++#if DARWIN_IOKIT_FULL_PATH
++#include <IOKit/network/IOUserEthernetController.h>
++#else
++#include <IOUserEthernetController.h>
++#endif
++#include <IOKit/storage/IOStorageDeviceCharacteristics.h>
++
++#include <CoreFoundation/CoreFoundation.h>
++#include <unistd.h>
++extern int IOEthernetControllerGetBSDSocket(IOEthernetControllerRef controller);
++extern io_object_t IOEthernetControllerGetIONetworkInterfaceObject(IOEthernetControllerRef controller);
++
++static IOEthernetControllerRef newController;
++
++kern_return_t
++IORegistryEntryGetProperty(
++    io_registry_entry_t   entry,
++    const io_name_t       propertyName,
++    io_struct_inband_t    buffer,
++    uint32_t            * size );
++
++static bool
++disable_dhcp_services(const char *ifName)
++{
++
++    SCPreferencesRef sc = SCPreferencesCreate(NULL, CFSTR("openvpn"), NULL);
++    CFArrayRef services = SCNetworkServiceCopyAll(sc);
++    CFIndex numKeys = CFArrayGetCount(services);
++    const CFStringRef ifCFName = CFStringCreateWithCString(NULL, ifName, kCFStringEncodingASCII);
++    bool found = false;
++
++    for (CFIndex i=0; i<numKeys; i++) {
++        SCNetworkServiceRef netSvc = CFArrayGetValueAtIndex(services, i);
++        SCNetworkInterfaceRef scInterface = SCNetworkServiceGetInterface(netSvc);
++        CFStringRef bsdName = SCNetworkInterfaceGetBSDName(scInterface);
++        if (bsdName != NULL && CFStringCompare(ifCFName, bsdName, 0) == 0) {
++            // Disables this OSX managed service but does not disable the interface
++            SCNetworkServiceSetEnabled(netSvc, false);
++            found = true;
++        }
++    }
++    CFRelease(services);
++    return found;
++}
++
++static char *
++copy_interface_name(IOEthernetControllerRef controller)
++{
++    CFStringRef     bsdName;
++    io_object_t     interface;
++
++    interface = IOEthernetControllerGetIONetworkInterfaceObject(controller);
++    if (interface == MACH_PORT_NULL) {
++        msg(M_ERR, "ERROR: could not get IO interface for IOEthernetController");
++        return NULL;
++    }
++
++    // It can take a bit for the interface to register
++    for (int i=0; i<10; i++) {
++        bsdName = IORegistryEntryCreateCFProperty(interface, CFSTR(kIOBSDNameKey), NULL, kNilOptions);
++        if (bsdName != NULL) break;
++        usleep(10000);
++    }
++    if (bsdName == NULL) {
++        msg(M_ERR, "ERROR: IOEthernetController with no BSD interface name");
++        return NULL;
++    }
++    CFIndex length = CFStringGetLength(bsdName);
++    CFIndex maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
++    char *buffer = (char *)malloc(maxSize);
++    if (buffer == NULL) {
++        msg(M_ERR, "ERROR: Unable to malloc space for BSD interface name");
++        return NULL;
++    }
++    if (!CFStringGetCString(bsdName, buffer, maxSize, kCFStringEncodingUTF8)) {
++        msg(M_ERR, "ERROR: Unable to convert bsdName to cstring");
++        free(buffer);
++        return NULL;
++    }
++    return buffer;
++}
++
++static struct ether_addr generate_random_mac(void) {
++    uint32_t rand1 = arc4random();
++    uint32_t rand2 = arc4random();
++    struct ether_addr rea = {.octet = {
++                                 (rand1 >> 0) & 0xff,
++                                 (rand1 >> 8) & 0xff,
++                                 (rand1 >> 16) & 0xff,
++                                 (rand1 >> 24) & 0xff,
++                                 (rand2 >> 0) & 0xff,
++                                 (rand2 >> 8) & 0xff,
++                             }};
++    rea.octet[0] |= 0x02;
++    rea.octet[0] &= 0xfe;
++    return rea;
++}
++
++#define    kSCNetworkInterfaceHiddenConfigurationKey        CFSTR("HiddenConfiguration")
++static IOEthernetControllerRef
++create_user_interface()
++{
++    CFMutableDictionaryRef mergeProperties, props;
++    IOEthernetControllerRef controller;
++    CFDataRef data;
++    struct ether_addr ea;
++
++    ea = generate_random_mac();
++
++    props = CFDictionaryCreateMutable(NULL, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
++    data = CFDataCreate(NULL, ea.octet, ETHER_ADDR_LEN);
++    CFDictionarySetValue(props, kIOEthernetHardwareAddress, data);
++    CFRelease(data);
++
++    mergeProperties = CFDictionaryCreateMutable(NULL, 3, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
++    CFDictionarySetValue(mergeProperties, CFSTR(kIOPropertyProductNameKey), CFSTR("OpenVPN TAP Ethernet"));
++    CFDictionarySetValue(mergeProperties, kIOUserEthernetInterfaceRole, CFSTR("hidden-ethernet"));
++    CFDictionarySetValue(mergeProperties, kSCNetworkInterfaceHiddenConfigurationKey, kCFBooleanTrue);
++    CFDictionarySetValue(props, kIOUserEthernetInterfaceMergeProperties, mergeProperties);
++    CFRelease(mergeProperties);
++
++    controller = IOEthernetControllerCreate(NULL, props);
++    CFRelease(props);
++    if (controller == NULL) {
++        msg(M_ERR, "ERROR: could not create ethernet controller for \"%s\"", ether_ntoa(&ea));
++        return NULL;
++    }
++
++    return controller;
++}
++
++#endif // TARGET_DARWIN
++
+ #ifdef _WIN32
+ 
+ const static GUID GUID_DEVCLASS_NET = { 0x4d36e972L, 0xe325, 0x11ce, { 0xbf, 0xc1, 0x08, 0x00, 0x2b, 0xe1, 0x03, 0x18 } };
+@@ -1789,7 +1928,36 @@ open_tun_generic(const char *dev, const char *dev_type, const char *dev_node,
+                 }
+                 if (!dynamic_opened)
+                 {
++#if TARGET_DARWIN
++                    char    *bsdName;
++                    msg(M_INFO, "Cannot allocate TUN/TAP dev dynamically");
++                    newController = create_user_interface();
++                    if (newController == NULL) {
++                        msg(M_FATAL, "ERROR: could not create controller");
++                        return;
++                    }
++
++                    IOEthernetControllerSetLinkStatus(newController, 1);
++                    tt->fd = IOEthernetControllerGetBSDSocket(newController);
++                    if (tt->fd == -1) {
++                        msg(M_FATAL, "ERROR: Unable to get BSD Socket for IOEthernetController");
++                    }
++                    dynamic_opened = true;
++                    bsdName = copy_interface_name(newController);
++                    if (bsdName == NULL) {
++                        msg(M_FATAL, "ERROR: no bsd name\n");
++                        return;
++                    }
++                    msg(M_INFO, "Got bsdname : %s\n", bsdName);
++                    strcpy(dynamic_name, bsdName);
++                    free(bsdName);
++                    msg(M_INFO, "Got name : %s\n", dynamic_name);
++                    if (!disable_dhcp_services(dynamic_name)) {
++                        msg(M_FATAL, "ERROR: Could not disable macOS services on %s", dynamic_name);
++                    }
++#else
+                     msg(M_FATAL, "Cannot allocate TUN/TAP dev dynamically");
++#endif
+                 }
+             }
+             /*

--- a/tunnelblick/MenuController.m
+++ b/tunnelblick/MenuController.m
@@ -1033,7 +1033,7 @@ TBSYNTHESIZE_OBJECT(retain, NSString     *, tunnelblickVersionString,  setTunnel
 		e = [loadTapConfigNames objectEnumerator];
 		while (  (configName = [e nextObject])  ) {
 			if (  ! [doNotLoadTapConfigNames containsObject: configName]  ) {
-				[gTbDefaults setObject: @"always" forKey: [configName stringByAppendingString: @"-loadTap"]];
+				[gTbDefaults setObject: @"never" forKey: [configName stringByAppendingString: @"-loadTap"]];
 			}
 		}
 		

--- a/tunnelblick/VPNConnection.m
+++ b/tunnelblick/VPNConnection.m
@@ -2654,6 +2654,10 @@ static pthread_mutex_t areConnectingMutex = PTHREAD_MUTEX_INITIALIZER;
 -(BOOL) mustLoad: (NSString *) requirement {
 
     // requirement must be "tun" or "tap". Returns true if the configuration requires the specified kext.
+    if ( [@"tap" isEqualToString: requirement] ) {
+        // TAP can be handled with IOUserEthernetController now
+        return NO;
+    }
 
 
     NSString * tunTapOrUtun = (  tunOrTap
@@ -2795,15 +2799,8 @@ static pthread_mutex_t areConnectingMutex = PTHREAD_MUTEX_INITIALIZER;
     }
 	if (  [preference isEqualToString: @"always"]  ) {
 		bitMask = bitMask | OPENVPNSTART_OUR_TAP_KEXT;
-	} else if (   (! preference)
-               || ( [preference length] == 0)  ) {
-        if (   ( ! tunOrTap )
-            || [tunOrTap isEqualToString: @"tap"]  ) {
-            bitMask = bitMask | OPENVPNSTART_OUR_TAP_KEXT;
-        }
     } else if (  ! [preference isEqualToString: @"never"]  ) {
-        [self addToLog: [NSString stringWithFormat: @"Cannot recognize the %@ preference value of '%@', so Tunnelblick will load the tap kext", preferenceKey, preference]];
-        bitMask = bitMask | OPENVPNSTART_OUR_TUN_KEXT;
+        [self addToLog: [NSString stringWithFormat: @"Cannot recognize the %@ preference value of '%@', so Tunnelblick will not load the tap kext", preferenceKey, preference]];
     }
     
 	preferenceKey = [displayName stringByAppendingString: @"-loadTun"];


### PR DESCRIPTION
This patch uses IOUserEthernet to support TAP tunnels on macOS. 

This also changes the default behavior for tap kext to not be to always try to load it.

It fetches the missing header from apple directly since the header is listed as APSL to avoid conflicts with GPL.

I'm happy to make or accept changes or work with you to clean up anything necessary.  I will be submitting the patch upstream but I suspect this might be a good place to get it ironed out more first, and you're welcome to do the upstream submission as well.

The patch is not yet applied to the oldest version of openvpn bundled.  It works with the two newer versions.