### PR TITLE
Announce crtext support, too

### DIFF
--- a/tunnelblick/tunnelblick-helper.m
+++ b/tunnelblick/tunnelblick-helper.m
@@ -2640,7 +2640,7 @@ int startVPN(NSString * configFile,
 
     [arguments addObject: @"--setenv"];
     [arguments addObject: @"IV_SSO"];
-    [arguments addObject: @"webauth"];
+    [arguments addObject: @"webauth,crtext"];
 
 	if (  (bitMask & OPENVPNSTART_TEST_MTU) != 0  ) {
         [arguments addObject: @"--mtu-test"];


### PR DESCRIPTION
Tunnelblick supports crtext for quite some time. It works fine. We should announce that, too.
Then servers could select the method they support.

Now: IV_SSO=webauth
Then: IV_SSO=webauth,crtext

We are using crtext with Tunnelblick in production. But currently we need a special solution for Tunnelblick, because it doesn't announce its support for crtext. We don't support webauth on server side.

Extends #767