### PR TITLE
Adds support for client-pending-auth using INFOMSG:CR_TEXT request

### DIFF
--- a/tunnelblick/VPNConnection.m
+++ b/tunnelblick/VPNConnection.m
@@ -4619,14 +4619,13 @@ static pthread_mutex_t lastStateMutex = PTHREAD_MUTEX_INITIALIZER;
                                          responseRequired:required
                                                  isStatic:isStatic];
 
-        if (response) {
-            [self addToLog:[NSString stringWithFormat:@"User responded to CR_TEXT challenge: '%@'", crPrompt]];
-        } else {
+        if (!response) {
             [self addToLog:[NSString stringWithFormat:@"Disconnecting: User cancelled when presented with static challenge: '%@'", crPrompt]];
             [self startDisconnectingUserKnows:@YES]; // User requested cancellation
             return;
         }
 
+        [self addToLog:[NSString stringWithFormat:@"User responded to CR_TEXT challenge: '%@'", crPrompt]];
         // Encode response and send
         NSData *responseData = [response dataUsingEncoding:NSUTF8StringEncoding];
         NSString *encodedResponse = base64Encode(responseData);

--- a/tunnelblick/VPNConnection.m
+++ b/tunnelblick/VPNConnection.m
@@ -4590,45 +4590,49 @@ static pthread_mutex_t lastStateMutex = PTHREAD_MUTEX_INITIALIZER;
         return;
     }
 
-    if (  [line hasPrefix: @">INFOMSG:CR_TEXT:"]  ) {
-        // This is currently not supporting any flags; it just opens the given URL
-        // in the default web browser.
-        NSString *pattern = @"^>INFOMSG:CR_TEXT:([^:]*):(.+)";
-        NSError *error = nil;
+    if ([line hasPrefix: @">INFOMSG:CR_TEXT:"]) {
+        // Remove the prefix from the line
+        NSString *prefix = @">INFOMSG:CR_TEXT:";
+        NSRange r = NSMakeRange(prefix.length, line.length - prefix.length);
+        NSString *payload = [line substringWithRange:r];
 
-        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
-        if (error) {
-            NSLog(@"Error creating regular expression: %@", error);
+        // Split the payload into two components: flags and prompt text
+        NSArray *items = [payload componentsSeparatedByString:@":"];
+        if (items.count != 2) {
+            NSLog(@"Syntax error in management command '%@'", line);
             return;
         }
 
-        NSRange range = NSMakeRange(0, line.length);
-        NSTextCheckingResult *match = [regex firstMatchInString:line options:0 range:range];
+        NSString *flagsString = items[0];
+        NSString *crPrompt = items[1];
 
-        if (match) {
-            NSString *crPrompt = [line substringWithRange:[match rangeAtIndex:2]];
-            // TODO: parse flags
-            [self addToLog: [NSString stringWithFormat: @"CR_TEXT prompt: %@", crPrompt]];
+        [self addToLog:[NSString stringWithFormat:@"CR_TEXT prompt: %@", crPrompt]];
 
-            NSString *response = nil;
+        // Parse flags
+        NSArray *flags = [flagsString componentsSeparatedByString:@","];
+        BOOL echo = [flags containsObject:@"E"];
+        BOOL required = [flags containsObject:@"R"];
+        BOOL isStatic = YES; // Currently always true for CR_TEXT
 
-            response = [self getResponseToChallenge: crPrompt
-                                       echoResponse: NO
-                                   responseRequired: YES
-                                           isStatic: YES];
-            if (  response  ) {
-                [self addToLog: [NSString stringWithFormat: @"User responded to CR_TEXT challenge: '%@'", crPrompt]];
-            } else {
-                [self addToLog: [NSString stringWithFormat: @"Disconnecting: User cancelled when presented with static challenge: '%@'", crPrompt]];
-                [self startDisconnectingUserKnows: @YES];      // (User requested it by cancelling)
-                return;
-            }
+        NSString *response = [self getResponseToChallenge:crPrompt
+                                             echoResponse:echo
+                                         responseRequired:required
+                                                 isStatic:isStatic];
 
-        [self sendStringToManagementSocket:[NSString stringWithFormat:@"cr-response \"%@\"\r\n", base64Encode([response dataUsingEncoding: NSUTF8StringEncoding])] encoding:NSUTF8StringEncoding];    
-
+        if (response) {
+            [self addToLog:[NSString stringWithFormat:@"User responded to CR_TEXT challenge: '%@'", crPrompt]];
         } else {
-            NSLog(@"No CR Prompt present in management command");
+            [self addToLog:[NSString stringWithFormat:@"Disconnecting: User cancelled when presented with static challenge: '%@'", crPrompt]];
+            [self startDisconnectingUserKnows:@YES]; // User requested cancellation
+            return;
         }
+
+        // Encode response and send
+        NSData *responseData = [response dataUsingEncoding:NSUTF8StringEncoding];
+        NSString *encodedResponse = base64Encode(responseData);
+        NSString *command = [NSString stringWithFormat:@"cr-response \"%@\"\r\n", encodedResponse];
+        [self sendStringToManagementSocket:command encoding:NSUTF8StringEncoding];
+
         return;
     }
 


### PR DESCRIPTION
See Tunnelblick#676 for protocol details. This change is a simple implementation and has some TODO left as I'm not an Objective-C developer at all.

Tested locally.