### PR TITLE
Complete list of public DNS to not falsely reject them

### DIFF
--- a/tunnelblick/FreePublicDnsServersList.txt
+++ b/tunnelblick/FreePublicDnsServersList.txt
@@ -26,7 +26,9 @@ OpenDNS Home	208.67.222.222	208.67.220.220	208.67.222.220	208.67.220.222	2620:11
 OpenNIC	107.150.40.234	50.116.23.211
 OpenNIC	69.195.152.204	23.94.60.240
 puntCAT	109.69.8.51
-Quad9 (was Global Cyber Alliance)	9.9.9.9
+Quad9 (Recommended)	9.9.9.9	149.112.112.112	2620:fe::fe	2620:fe::9
+Quad9 (Secured w/ECS)	9.9.9.11	149.112.112.11	2620:fe::11	2620:fe::fe:11
+Quad9 (Unsecured)	9.9.9.10	149.112.112.10	2620:fe::10	2620:fe::fe:10
 SafeDNS	195.46.39.39	195.46.39.40
 SmartViper	208.76.50.50	208.76.51.51
 UncensoredDNS (was censurfridns.dk)	91.239.100.100	89.233.43.71

--- a/tunnelblick/FreePublicDnsServersList.txt
+++ b/tunnelblick/FreePublicDnsServersList.txt
@@ -33,4 +33,6 @@ SafeDNS	195.46.39.39	195.46.39.40
 SmartViper	208.76.50.50	208.76.51.51
 UncensoredDNS (was censurfridns.dk)	91.239.100.100	89.233.43.71
 Verisign	64.6.64.6	64.6.65.6
-Yandex.DNS (was Yandex)	77.88.8.8	77.88.8.1
+Yandex (common)	77.88.8.8	77.88.8.1	2a02:6b8:0:1::feed:ff	2a02:6b8::feed:ff
+Yandex (safe)	77.88.8.2	77.88.8.88	2a02:6b8::feed:bad	2a02:6b8:0:1::feed:bad
+Yandex (family)	77.88.8.3	77.88.8.7	2a02:6b8::feed:a11	2a02:6b8:0:1::feed:a11


### PR DESCRIPTION
In my IPv6-mostly network, my OpenVPN server hands out these name severs to clients:
```
13:36:33 *Tunnelblick:  DNS servers 'fd00:99::1 2620:fe::fe 9.9.9.9' will be used for DNS queries when the VPN is active
```

Tunnelblick is the only client rejecting both IPv6 addresses:
```
13:36:33 *Tunnelblick:  NOTE: The DNS servers include one or more free public DNS servers known to Tunnelblick and one or more DNS servers not known to Tunnelblick. If used, the DNS servers not known to Tunnelblick may cause DNS queries to fail or be intercepted or falsified even if they are directed through the VPN. Specify only known public DNS servers or DNS servers located on the VPN network to avoid such problems.
```

Reading this, I thought it complains only about the Unique Local Address from `fc00::/7`:
```
2025-10-04 13:36:35.083646 *Tunnelblick: Warning: DNS server address fd00:99::1 is not being used.
```

But it also considers the well-known public IPv6 address of `dns.quad9.net` to be not trustworthy:
```
2025-10-04 13:36:35.086468 *Tunnelblick: Warning: DNS server address 2620:fe::fe is not being used.
```

So macOS clients in my IPv6-mostly network end up with a single IPv4 nameserver, which works, but is not expected.

Thus I've added missing information for Quad9 and while here completed another public service I know of as well.