### PR TITLE
IPv6 on tap related modifications

### DIFF
--- a/tunnelblick/client.down.tunnelblick.sh
+++ b/tunnelblick/client.down.tunnelblick.sh
@@ -445,7 +445,7 @@ release_ipv6() {
                                         "Error happened trying to release IPv6 addresses" \
                                         /usr/sbin/ipconfig set "$dev" NONE-V6
     fi
-
+}
 ##########################################################################################
 restore_ipv6() {
 

--- a/tunnelblick/client.down.tunnelblick.sh
+++ b/tunnelblick/client.down.tunnelblick.sh
@@ -437,6 +437,16 @@ EOF
 }
 
 ##########################################################################################
+release_ipv6() {
+
+    # Releases IPv6 addresses on TAP interface
+    if ${ARG_TAP} ; then
+        execute_command "Released IPv6 addresses" \
+                                        "Error happened trying to release IPv6 addresses" \
+                                        /usr/sbin/ipconfig set "$dev" NONE-V6
+    fi
+
+##########################################################################################
 restore_ipv6() {
 
     # Undoes the actions performed by the disable_ipv6() routine in client.up.tunnelblick.sh by restoring
@@ -770,6 +780,8 @@ else
 	profile_or_execute remove_leasewatcher
 
 	profile_or_execute release_dhcp
+
+    profile_or_execute release_ipv6
 
 	profile_or_execute restore_disabled_network_services
 

--- a/tunnelblick/client.route-pre-down.tunnelblick.sh
+++ b/tunnelblick/client.route-pre-down.tunnelblick.sh
@@ -270,8 +270,31 @@ EOF
     else
         logMessage "NOTE: No DHCP release by ${OUR_NAME} is needed because this TAP connection does not use DHCP via the TAP device."
 	fi
+
+    # Release IPV6 addresses
+            # shellcheck disable=2154
+    if [ -z "$dev" ]; then
+        # If $dev is not defined, then use TunnelDevice, which was set from $dev by client.up.tunnelblick.sh
+        # ($dev is not defined when this script is called from MenuController to clean up when OpenVPN has crashed)
+        if [ -n "${sTunnelDevice}" ]; then
+            logMessage "ERROR: \$dev not defined; using TunnelDevice: ${sTunnelDevice}"
+            set +e
+                                    ipconfig set "${sTunnelDevice}" NONE-V6 2>/dev/null
+            set -e
+            logMessage "Released IPv6 addresses via ipconfig set \"${sTunnelDevice}\" NONE."
+        else
+            logMessage "WARNING: Cannot release IPv6 addresses without \$dev or State:/Network/OpenVPN/TunnelDevice being defined. Device may not have disconnected properly."
+        fi
+    else
+        set +e
+                            ipconfig set "$dev" NONE-V6 2>/dev/null
+        set -e
+        logMessage "Released IPv6 addresses via ipconfig set \"$dev\" NONE-V6."
+    fi
+
 else
-    logMessage "No DHCP release by ${OUR_NAME} is needed because this is not a TAP connection."
+    logMessage "No DHCP and IPV6 addresses release by ${OUR_NAME} is needed because this is not a TAP connection."
+
 fi
 
 disableNetworkAccess $ARG_DISABLE_INTERNET_ACCESS_AFTER_DISCONNECTING $ARG_DISABLE_INTERNET_ACCESS_AFTER_DISCONNECTING_UNEXPECTED

--- a/tunnelblick/client.up.tunnelblick.sh
+++ b/tunnelblick/client.up.tunnelblick.sh
@@ -1548,26 +1548,13 @@ configureDhcpDns() {
 					(( nWinsServerIndex++ ))
 				done
 
-				for tSearchDomain in $( echo "$sGetPacketOutput" | grep "search_domain" | grep -Eo "\{([-A-Za-z0-9\-\.]+)(, [-A-Za-z0-9\-\.]+)*\}" | grep -Eo "([-A-Za-z0-9\-\.]+)" ); do
+				for tSearchDomain in $( echo "$sGetPacketOutput" | grep -e "search_domain" -e "domain_search" | grep -Eo "\{([-A-Za-z0-9\-\.]+)(, [-A-Za-z0-9\-\.]+)*\}" | grep -Eo "([-A-Za-z0-9\-\.]+)" ); do
 					aSearchDomains[nSearchDomainIndex-1]="$( trim "$tSearchDomain" )"
 					(( nSearchDomainIndex++ ))
 				done
 
 				sDomainName="$( echo "$sGetPacketOutput" | grep "domain_name " | grep -Eo ": [-A-Za-z0-9\-\.]+" | grep -Eo "[-A-Za-z0-9\-\.]+" )"
 				sDomainName="$( trim "$sDomainName" )"
-
-				if [ ${#aNameServers[*]} -gt 0 ] && [ "$sDomainName" ]; then
-					logMessage "Retrieved from DHCP/BOOTP packet: name server(s) [" "${aNameServers[@]}" "], domain name [ $sDomainName ], search domain(s) [" "${aSearchDomains[@]}" "] and SMB server(s) [" "${aWinsServers[@]}" "]"
-					setDnsServersAndDomainName aNameServers[@] "$sDomainName" aWinsServers[@] aSearchDomains[@]
-					return 0
-				elif [ ${#aNameServers[*]} -gt 0 ]; then
-					logMessage "Retrieved from DHCP/BOOTP packet: name server(s) [" "${aNameServers[@]}" "], search domain(s) [" "${aSearchDomains[@]}" "] and SMB server(s) [" "${aWinsServers[@]}" "] and using default domain name [ $DEFAULT_DOMAIN_NAME ]"
-					setDnsServersAndDomainName aNameServers[@] "$DEFAULT_DOMAIN_NAME" aWinsServers[@] aSearchDomains[@]
-					return 0
-				else
-					# Should we return 1 here and indicate an error, or attempt the old method?
-					logMessage "No useful information extracted from DHCP/BOOTP packet. Attempting legacy configuration."
-				fi
 
 			set -e # We instruct bash that it CAN again fail on errors
 		else
@@ -1577,6 +1564,49 @@ configureDhcpDns() {
 	else
 		logMessage "WARNING: Failed or had no output: 'ipconfig getpacket \"$dev\"'"
 	fi
+
+    if ${ARG_ENABLE_IPV6_ON_TAP} ; then
+        logDebugMessage "About to 'ipconfig getv6packet $dev' as IPV6 on TAP is enabled"
+        sGetPacketOutput6="$( ipconfig getv6packet "$dev" ; true )"
+        logDebugMessage "Completed 'ipconfig getv6packet $dev'; sGetPacketOutput = $sGetPacketOutput6"
+
+        if [ "$sGetPacketOutput6" ]; then
+            sGetPacketOutput6_FirstLine="$( echo "$sGetPacketOutput6" | head -n 1 )"
+            logDebugMessage "sGetPacketOutput_FirstLine = $sGetPacketOutput6_FirstLine"
+
+            if [[ $sGetPacketOutput6_FirstLine == DHCPv6\ REPLY* ]]; then
+                set +e # "grep" will return error status (1) if no matches are found, so don't fail on individual errors
+
+                        for tNameServer6 in $( echo "$sGetPacketOutput6" | grep "DNS_SERVERS" | sed "s/.*DNS_SERVERS.* Length[^:]*: //"  | grep -Eo "([0-9a-f:]+)(, [0-9a-f:]+)*" | grep -Eo  "([0-9a-f:]+)" ); do
+                                aNameServers[nNameServerIndex-1]="$( trim "$tNameServer6" )"
+                                (( nNameServerIndex++ ))
+                        done
+
+                        for tSearchDomain6 in $( echo "$sGetPacketOutput6" | grep "DOMAIN_LIST" | grep -Eo "\{([-A-Za-z0-9\-\.]+)(, [-A-Za-z0-9\-\.]+)*\}" | grep -Eo "([-A-Za-z0-9\-\.]+)" ); do
+                                aSearchDomains[nSearchDomainIndex-1]="$( trim "$tSearchDomain6" )"
+                                (( nSearchDomainIndex++ ))
+                        done
+            else
+                # Should we return 1 here and indicate an error, or attempt the old method?
+                logMessage "No DHCPv6 packet found on interface. Attempting legacy configuration."
+            fi
+        else
+            logMessage "WARNING: Failed or had no output: 'ipconfig getv6packet \"$dev\"'"
+        fi
+    fi
+
+    if [ ${#aNameServers[*]} -gt 0 ] && [ "$sDomainName" ]; then
+            logMessage "Retrieved from DHCP/BOOTP or DHCPv6 packet: name server(s) [" "${aNameServers[@]}" "], domain name [ $sDomainName ], search domain(s) [" "${aSearchDomains[@]}" "] and SMB server(s) [" "${aWinsServers[@]}" "]"
+            setDnsServersAndDomainName aNameServers[@] "$sDomainName" aWinsServers[@] aSearchDomains[@]
+            return 0
+    elif [ ${#aNameServers[*]} -gt 0 ]; then
+            logMessage "Retrieved from DHCP/BOOTP or DHCPv6 packet: name server(s) [" "${aNameServers[@]}" "], search domain(s) [" "${aSearchDomains[@]}" "] and SMB server(s) [" "${aWinsServers[@]}" "] and using default domain name [ $DEFAULT_DOMAIN_NAME ]"
+            setDnsServersAndDomainName aNameServers[@] "$DEFAULT_DOMAIN_NAME" aWinsServers[@] aSearchDomains[@]
+            return 0
+    else
+            # Should we return 1 here and indicate an error, or attempt the old method?
+            logMessage "No useful information extracted from DHCP/BOOTP or DHCPv6 packet. Attempting legacy configuration."
+    fi
 
 	unset sDomainName
 	unset sNameServer
@@ -2208,7 +2238,7 @@ if ${ARG_TAP} ; then
 	else
 		if [ -z "${route_vpn_gateway}" ] || [ "$route_vpn_gateway" == "dhcp" ] || [ "$route_vpn_gateway" == "DHCP" ]; then
 			# Check if $dev already has an ip configuration
-			hasIp="$(ifconfig "$dev" | grep inet | cut -d ' ' -f 2)"
+			hasIp="$(ifconfig "$dev" | grep "inet[^6]" | cut -d ' ' -f 2)"
 			if [ "${hasIp}" ]; then
 				logMessage "Not using DHCP because $dev already has an IP configuration ($hasIp). route_vpn_gateway = '$route_vpn_gateway'"
 			else


### PR DESCRIPTION
Hi,

Enabling IPv6 on tap (feth) interface could lead to an automatic IPv6 address assignment  (*Tunnelblick:  Did 'ipconfig set "feth0" AUTOMATIC-V6'). When a vpn connection is terminated, interface (if not destroyed) must remain without ip/ipv6 addresses. This patch makes the equivalent of ipv4 dhcp_release. 

In addition, ifconfig command returns ip/ipv6 entries for a given interface. Addresses are preceeded by inet or inet6. In client.up script, a grep inet will also return inet6 entries, so when used as condition for dhcp initiation, its behavior is not correct.

This patch also adds support for IPv6 dns servers and domain search integration. At the same time, it also extends the use of  "search_domain" to "domain_search" while retrieving entries from ipconfig getpacket.