### PR TITLE
Use a certificate and private key from the Keychain (management-external-cert/key)

### DIFF
--- a/tunnelblick/TBKeychainIdentity.h
+++ b/tunnelblick/TBKeychainIdentity.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Andrew Grishenko. All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, see http://www.gnu.org/licenses/.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
+
+// Finds identities (a certificate together with its private key) in the user's Keychain and signs
+// data with them, so that OpenVPN's "--management-external-cert" and "--management-external-key"
+// options can be used on macOS instead of the Windows-only "--cryptoapicert" option.
+//
+// The argument to "--management-external-cert" is passed through to the management interface in the
+// ">NEED-CERTIFICATE:" message and is used here to select which identity to use. The syntax mirrors
+// the syntax of "--cryptoapicert":
+//
+//      SUBJ:<string>   Use the identity whose certificate's subject contains <string>
+//      ISSUER:<string> Use the identity whose certificate's issuer contains <string>
+//      THUMB:<string>  Use the identity whose certificate's SHA-1 fingerprint is <string>
+//
+// A selector without one of those prefixes is interpreted as if it had the "SUBJ:" prefix.
+
+@interface TBKeychainIdentity : NSObject
+
+// Returns a retained SecIdentityRef which the caller must CFRelease(), or NULL if an identity could
+// not be found (in which case *errMsgPtr is set to a localized message describing the problem).
++(SecIdentityRef) copyIdentityMatchingSelector: (NSString *)  selector
+                                  errorMessage: (NSString **) errMsgPtr;
+
+// Returns the identity's certificate as PEM (including the "-----BEGIN CERTIFICATE-----" and
+// "-----END CERTIFICATE-----" lines, separated by LF characters, without a trailing LF), or nil if
+// it could not be obtained (in which case *errMsgPtr is set to a localized message).
++(NSString *) pemForIdentity: (SecIdentityRef) identity
+                errorMessage: (NSString **)    errMsgPtr;
+
+// Signs data with the identity's private key and returns the signature, or nil if the data could
+// not be signed (in which case *errMsgPtr is set to a localized message).
+//
+// 'algorithm' is the algorithm string from the management interface's ">PK_SIGN:" message (that is,
+// everything after the comma that follows the base64-encoded data). It may be nil or empty, which
+// happens with the obsolete ">RSA_SIGN:" message and means "RSA_PKCS1_PADDING".
++(NSData *) signData: (NSData *)        data
+        withIdentity: (SecIdentityRef)  identity
+           algorithm: (NSString *)      algorithm
+        errorMessage: (NSString **)     errMsgPtr;
+
+// Returns a one-line description of an identity's certificate ("subject; SHA-1 fingerprint"), for
+// use in the Tunnelblick log. Returns nil if the description could not be created.
++(NSString *) descriptionForIdentity: (SecIdentityRef) identity;
+
+@end

--- a/tunnelblick/TBKeychainIdentity.m
+++ b/tunnelblick/TBKeychainIdentity.m
@@ -1,0 +1,675 @@
+/*
+ * Copyright 2026 Andrew Grishenko. All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, see http://www.gnu.org/licenses/.
+ */
+
+#import "TBKeychainIdentity.h"
+
+#import <CommonCrypto/CommonDigest.h>
+
+#import "helper.h"
+
+typedef enum {
+    TBKeychainMatchSubject,
+    TBKeychainMatchIssuer,
+    TBKeychainMatchThumbprint
+} TBKeychainMatchType;
+
+@implementation TBKeychainIdentity
+
+//**************************************************************************************************
+// Errors
+
++(NSString *) messageForOSStatus: (OSStatus) status {
+
+    CFStringRef cfMessage = SecCopyErrorMessageString(status, NULL);
+    if (  cfMessage == NULL  ) {
+        return [NSString stringWithFormat: @"status = %d", (int)status];
+    }
+
+    NSString * message = [NSString stringWithFormat: @"status = %d: '%@'", (int)status, (__bridge NSString *)cfMessage];
+    CFRelease(cfMessage);
+    return message;
+}
+
++(NSString *) messageForCFError: (CFErrorRef) error {
+
+    if (  error == NULL  ) {
+        return @"an unknown error occurred";
+    }
+
+    return [(__bridge NSError *)error localizedDescription];
+}
+
+//**************************************************************************************************
+// Getting strings out of a certificate
+
++(NSString *) shortNameForOID: (NSString *) oid {
+
+    // Returns the conventional abbreviation for the OID of a distinguished name component, or the
+    // OID itself if there is no conventional abbreviation for it.
+
+    static NSDictionary * shortNames = nil;
+    if (  shortNames == nil  ) {
+        shortNames = [[NSDictionary alloc] initWithObjectsAndKeys:
+                      @"CN",           @"2.5.4.3",
+                      @"SN",           @"2.5.4.4",
+                      @"serialNumber", @"2.5.4.5",
+                      @"C",            @"2.5.4.6",
+                      @"L",            @"2.5.4.7",
+                      @"ST",           @"2.5.4.8",
+                      @"STREET",       @"2.5.4.9",
+                      @"O",            @"2.5.4.10",
+                      @"OU",           @"2.5.4.11",
+                      @"T",            @"2.5.4.12",
+                      @"GN",           @"2.5.4.42",
+                      @"emailAddress", @"1.2.840.113549.1.9.1",
+                      @"UID",          @"0.9.2342.19200300.100.1.1",
+                      @"DC",           @"0.9.2342.19200300.100.1.25",
+                      nil];
+    }
+
+    NSString * shortName = [shortNames objectForKey: oid];
+    return (  shortName
+            ? shortName
+            : oid);
+}
+
++(NSString *) distinguishedNameFromCertificate: (SecCertificateRef) certificate
+                                        forOID: (CFStringRef)       nameOID {
+
+    // Returns a distinguished name (the subject or the issuer of a certificate) as a string such as
+    //      "C=US, O=Example, OU=IT, CN=John Doe"
+    // with the components in the order in which they appear in the certificate.
+    //
+    // Returns nil if the name could not be obtained from the certificate.
+
+    if (  certificate == NULL  ) {
+        return nil;
+    }
+
+    CFArrayRef keys = CFArrayCreate(NULL, (const void **)&nameOID, 1, &kCFTypeArrayCallBacks);
+    if (  keys == NULL  ) {
+        return nil;
+    }
+
+    CFErrorRef error = NULL;
+    CFDictionaryRef values = SecCertificateCopyValues(certificate, keys, &error);
+    CFRelease(keys);
+
+    if (  values == NULL  ) {
+        if (  error != NULL  ) {
+            CFRelease(error);
+        }
+        return nil;
+    }
+    if (  error != NULL  ) {
+        CFRelease(error);
+    }
+
+    NSString * result = nil;
+
+    NSDictionary * nameEntry = [(__bridge NSDictionary *)values objectForKey: (__bridge NSString *)nameOID];
+    NSArray * components = [nameEntry objectForKey: (__bridge NSString *)kSecPropertyKeyValue];
+    if (  [components isKindOfClass: [NSArray class]]  ) {
+
+        NSMutableArray * parts = [NSMutableArray arrayWithCapacity: [components count]];
+        NSUInteger ix;
+        for (  ix=0; ix<[components count]; ix++  ) {
+            NSDictionary * component = [components objectAtIndex: ix];
+            if (  ! [component isKindOfClass: [NSDictionary class]]  ) {
+                continue;
+            }
+            NSString * label = [component objectForKey: (__bridge NSString *)kSecPropertyKeyLabel];
+            id         value = [component objectForKey: (__bridge NSString *)kSecPropertyKeyValue];
+            if (   [label isKindOfClass: [NSString class]]
+                && [value isKindOfClass: [NSString class]]  ) {
+                [parts addObject: [NSString stringWithFormat: @"%@=%@", [self shortNameForOID: label], value]];
+            }
+        }
+
+        if (  [parts count] != 0  ) {
+            result = [parts componentsJoinedByString: @", "];
+        }
+    }
+
+    CFRelease(values);
+
+    return result;
+}
+
++(NSString *) sha1FingerprintOfCertificate: (SecCertificateRef) certificate {
+
+    // Returns the SHA-1 fingerprint of a certificate as a lowercase hexadecimal string without
+    // separators, or nil if it could not be calculated.
+
+    if (  certificate == NULL  ) {
+        return nil;
+    }
+
+    CFDataRef der = SecCertificateCopyData(certificate);
+    if (  der == NULL  ) {
+        return nil;
+    }
+
+    unsigned char digest[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1(CFDataGetBytePtr(der), (CC_LONG)CFDataGetLength(der), digest);
+    CFRelease(der);
+
+    NSMutableString * fingerprint = [NSMutableString stringWithCapacity: 2 * CC_SHA1_DIGEST_LENGTH];
+    unsigned ix;
+    for (  ix=0; ix<CC_SHA1_DIGEST_LENGTH; ix++  ) {
+        [fingerprint appendFormat: @"%02x", digest[ix]];
+    }
+
+    return [NSString stringWithString: fingerprint];
+}
+
++(BOOL) certificateIsCurrentlyValid: (SecCertificateRef) certificate {
+
+    // Returns YES if 'now' is within the certificate's validity period.
+    //
+    // Returns YES if the validity period could not be obtained: it is up to OpenVPN and the server
+    // to reject a certificate; all this does is avoid using an obviously expired certificate when
+    // the Keychain contains both an expired one and a current one that match the selector.
+
+    if (  certificate == NULL  ) {
+        return NO;
+    }
+
+    const void * keys[] = { kSecOIDX509V1ValidityNotBefore, kSecOIDX509V1ValidityNotAfter };
+    CFArrayRef keysArray = CFArrayCreate(NULL, keys, 2, &kCFTypeArrayCallBacks);
+    if (  keysArray == NULL  ) {
+        return YES;
+    }
+
+    CFErrorRef error = NULL;
+    CFDictionaryRef values = SecCertificateCopyValues(certificate, keysArray, &error);
+    CFRelease(keysArray);
+
+    if (  values == NULL  ) {
+        if (  error != NULL  ) {
+            CFRelease(error);
+        }
+        return YES;
+    }
+    if (  error != NULL  ) {
+        CFRelease(error);
+    }
+
+    BOOL isValid = YES;
+
+    NSDictionary * dict = (__bridge NSDictionary *)values;
+    NSNumber * notBefore = [[dict objectForKey: (__bridge NSString *)kSecOIDX509V1ValidityNotBefore] objectForKey: (__bridge NSString *)kSecPropertyKeyValue];
+    NSNumber * notAfter  = [[dict objectForKey: (__bridge NSString *)kSecOIDX509V1ValidityNotAfter ] objectForKey: (__bridge NSString *)kSecPropertyKeyValue];
+
+    CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
+
+    if (   [notBefore isKindOfClass: [NSNumber class]]
+        && (now < [notBefore doubleValue])  ) {
+        isValid = NO;
+    }
+    if (   [notAfter isKindOfClass: [NSNumber class]]
+        && (now > [notAfter doubleValue])  ) {
+        isValid = NO;
+    }
+
+    CFRelease(values);
+
+    return isValid;
+}
+
++(CFAbsoluteTime) notBeforeOfCertificate: (SecCertificateRef) certificate {
+
+    // Returns the certificate's notBefore as a CFAbsoluteTime, or 0.0 if it could not be obtained.
+    // Used only to choose the newest certificate when several of them match the selector.
+
+    if (  certificate == NULL  ) {
+        return 0.0;
+    }
+
+    const void * keys[] = { kSecOIDX509V1ValidityNotBefore };
+    CFArrayRef keysArray = CFArrayCreate(NULL, keys, 1, &kCFTypeArrayCallBacks);
+    if (  keysArray == NULL  ) {
+        return 0.0;
+    }
+
+    CFErrorRef error = NULL;
+    CFDictionaryRef values = SecCertificateCopyValues(certificate, keysArray, &error);
+    CFRelease(keysArray);
+
+    if (  values == NULL  ) {
+        if (  error != NULL  ) {
+            CFRelease(error);
+        }
+        return 0.0;
+    }
+    if (  error != NULL  ) {
+        CFRelease(error);
+    }
+
+    CFAbsoluteTime notBefore = 0.0;
+
+    NSDictionary * dict = (__bridge NSDictionary *)values;
+    NSNumber * number = [[dict objectForKey: (__bridge NSString *)kSecOIDX509V1ValidityNotBefore] objectForKey: (__bridge NSString *)kSecPropertyKeyValue];
+    if (  [number isKindOfClass: [NSNumber class]]  ) {
+        notBefore = [number doubleValue];
+    }
+
+    CFRelease(values);
+
+    return notBefore;
+}
+
++(NSString *) descriptionForIdentity: (SecIdentityRef) identity {
+
+    if (  identity == NULL  ) {
+        return nil;
+    }
+
+    SecCertificateRef certificate = NULL;
+    OSStatus status = SecIdentityCopyCertificate(identity, &certificate);
+    if (   (status != errSecSuccess)
+        || (certificate == NULL)  ) {
+        return nil;
+    }
+
+    NSString * subject     = [self distinguishedNameFromCertificate: certificate forOID: kSecOIDX509V1SubjectName];
+    NSString * fingerprint = [self sha1FingerprintOfCertificate: certificate];
+    CFRelease(certificate);
+
+    return [NSString stringWithFormat: @"%@; SHA-1 %@",
+            (  subject     ? subject     : @"(unknown subject)"),
+            (  fingerprint ? fingerprint : @"(unknown fingerprint)")];
+}
+
+//**************************************************************************************************
+// Finding an identity
+
++(BOOL) certificate: (SecCertificateRef) certificate
+     matchesPattern: (NSString *)        pattern
+            forType: (TBKeychainMatchType) matchType {
+
+    switch (  matchType  ) {
+
+        case TBKeychainMatchThumbprint: {
+            NSString * fingerprint = [self sha1FingerprintOfCertificate: certificate];
+            return (   (fingerprint != nil)
+                    && ([fingerprint caseInsensitiveCompare: pattern] == NSOrderedSame));
+        }
+
+        case TBKeychainMatchIssuer: {
+            NSString * issuer = [self distinguishedNameFromCertificate: certificate forOID: kSecOIDX509V1IssuerName];
+            return (   (issuer != nil)
+                    && ([issuer rangeOfString: pattern options: NSCaseInsensitiveSearch].length != 0));
+        }
+
+        case TBKeychainMatchSubject:
+        default: {
+            NSString * subject = [self distinguishedNameFromCertificate: certificate forOID: kSecOIDX509V1SubjectName];
+            return (   (subject != nil)
+                    && ([subject rangeOfString: pattern options: NSCaseInsensitiveSearch].length != 0));
+        }
+    }
+}
+
++(BOOL) parseSelector: (NSString *)           selector
+          intoPattern: (NSString **)          patternPtr
+            matchType: (TBKeychainMatchType *) matchTypePtr
+         errorMessage: (NSString **)          errMsgPtr {
+
+    NSString * trimmed = [selector stringByTrimmingCharactersInSet: [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+
+    // OpenVPN strips the quotation marks that surround an option's argument, but strip them here,
+    // too, so that a selector that was quoted twice still works.
+    if (   ([trimmed length] > 1)
+        && [trimmed hasPrefix: @"\""]
+        && [trimmed hasSuffix: @"\""]  ) {
+        trimmed = [trimmed substringWithRange: NSMakeRange(1, [trimmed length] - 2)];
+    }
+
+    if (  [trimmed length] == 0  ) {
+        *errMsgPtr = NSLocalizedString(@"The 'management-external-cert' option does not specify which certificate to use.", @"Window text");
+        return NO;
+    }
+
+    if (  [[trimmed uppercaseString] hasPrefix: @"THUMB:"]  ) {
+        *matchTypePtr = TBKeychainMatchThumbprint;
+        NSString * thumbprint = [trimmed substringFromIndex: [@"THUMB:" length]];
+
+        // Accept the separators that are used when a fingerprint is displayed by Keychain Access,
+        // by OpenSSL, and by Windows' certificate manager.
+        thumbprint = [thumbprint stringByReplacingOccurrencesOfString: @" "  withString: @""];
+        thumbprint = [thumbprint stringByReplacingOccurrencesOfString: @":"  withString: @""];
+        *patternPtr = thumbprint;
+
+    } else if (  [[trimmed uppercaseString] hasPrefix: @"ISSUER:"]  ) {
+        *matchTypePtr = TBKeychainMatchIssuer;
+        *patternPtr   = [trimmed substringFromIndex: [@"ISSUER:" length]];
+
+    } else if (  [[trimmed uppercaseString] hasPrefix: @"SUBJ:"]  ) {
+        *matchTypePtr = TBKeychainMatchSubject;
+        *patternPtr   = [trimmed substringFromIndex: [@"SUBJ:" length]];
+
+    } else {
+        *matchTypePtr = TBKeychainMatchSubject;
+        *patternPtr   = trimmed;
+    }
+
+    if (  [*patternPtr length] == 0  ) {
+        *errMsgPtr = [NSString stringWithFormat:
+                      NSLocalizedString(@"The 'management-external-cert' option's argument ('%@') does not specify which certificate to use.", @"Window text; the '%@' is replaced by an OpenVPN option's argument"),
+                      selector];
+        return NO;
+    }
+
+    return YES;
+}
+
++(SecIdentityRef) copyIdentityMatchingSelector: (NSString *)  selector
+                                  errorMessage: (NSString **) errMsgPtr {
+
+    NSString          * pattern   = nil;
+    TBKeychainMatchType matchType = TBKeychainMatchSubject;
+    if (  ! [self parseSelector: selector intoPattern: &pattern matchType: &matchType errorMessage: errMsgPtr]  ) {
+        return NULL;
+    }
+
+    NSDictionary * query = [NSDictionary dictionaryWithObjectsAndKeys:
+                            (__bridge id)kSecClassIdentity, (__bridge id)kSecClass,
+                            (__bridge id)kSecMatchLimitAll, (__bridge id)kSecMatchLimit,
+                            (id)kCFBooleanTrue,             (__bridge id)kSecReturnRef,
+                            nil];
+
+    CFTypeRef result = NULL;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
+
+    if (  status == errSecItemNotFound  ) {
+        *errMsgPtr = NSLocalizedString(@"There are no certificates with private keys in the Keychain.", @"Window text");
+        return NULL;
+    }
+
+    if (   (status != errSecSuccess)
+        || (result == NULL)  ) {
+        *errMsgPtr = [NSString stringWithFormat:
+                      NSLocalizedString(@"Could not search the Keychain for certificates (%@).", @"Window text; the '%@' is replaced by a description of an error"),
+                      [self messageForOSStatus: status]];
+        if (  result != NULL  ) {
+            CFRelease(result);
+        }
+        return NULL;
+    }
+
+    NSArray * identities = (__bridge NSArray *)result;
+
+    SecIdentityRef bestIdentity  = NULL;
+    CFAbsoluteTime bestNotBefore = 0.0;
+    unsigned       matchCount    = 0;
+    unsigned       expiredCount  = 0;
+
+    NSUInteger ix;
+    for (  ix=0; ix<[identities count]; ix++  ) {
+
+        SecIdentityRef identity = (SecIdentityRef)[identities objectAtIndex: ix];
+
+        SecCertificateRef certificate = NULL;
+        if (   (SecIdentityCopyCertificate(identity, &certificate) != errSecSuccess)
+            || (certificate == NULL)  ) {
+            continue;
+        }
+
+        if (  ! [self certificate: certificate matchesPattern: pattern forType: matchType]  ) {
+            CFRelease(certificate);
+            continue;
+        }
+
+        matchCount++;
+
+        if (  ! [self certificateIsCurrentlyValid: certificate]  ) {
+            expiredCount++;
+            appendLog([NSString stringWithFormat: @"Keychain identity matches '%@' but is not valid at this time, so it is being ignored: %@",
+                       selector, [self descriptionForIdentity: identity]]);
+            CFRelease(certificate);
+            continue;
+        }
+
+        appendLog([NSString stringWithFormat: @"Keychain identity matches '%@': %@",
+                   selector, [self descriptionForIdentity: identity]]);
+
+        // If more than one identity matches, use the one that was issued most recently
+        CFAbsoluteTime notBefore = [self notBeforeOfCertificate: certificate];
+        if (   (bestIdentity == NULL)
+            || (notBefore > bestNotBefore)  ) {
+            if (  bestIdentity != NULL  ) {
+                CFRelease(bestIdentity);
+            }
+            bestIdentity  = (SecIdentityRef)CFRetain(identity);
+            bestNotBefore = notBefore;
+        }
+
+        CFRelease(certificate);
+    }
+
+    CFRelease(result);
+
+    if (  bestIdentity == NULL  ) {
+        if (  expiredCount != 0  ) {
+            *errMsgPtr = [NSString stringWithFormat:
+                          NSLocalizedString(@"The Keychain contains %u certificate(s) that match '%@', but none of them is valid at this time.", @"Window text; the '%u' is replaced by a number and the '%@' is replaced by an OpenVPN option's argument"),
+                          expiredCount, selector];
+        } else {
+            *errMsgPtr = [NSString stringWithFormat:
+                          NSLocalizedString(@"The Keychain does not contain a certificate with a private key that matches '%@'.", @"Window text; the '%@' is replaced by an OpenVPN option's argument"),
+                          selector];
+        }
+        return NULL;
+    }
+
+    if (  matchCount > 1  ) {
+        appendLog([NSString stringWithFormat: @"%u Keychain identities match '%@'; using %@",
+                   matchCount, selector, [self descriptionForIdentity: bestIdentity]]);
+    }
+
+    return bestIdentity;
+}
+
+//**************************************************************************************************
+// Using an identity
+
++(NSString *) pemForIdentity: (SecIdentityRef) identity
+                errorMessage: (NSString **)    errMsgPtr {
+
+    if (  identity == NULL  ) {
+        *errMsgPtr = NSLocalizedString(@"No Keychain certificate has been selected.", @"Window text");
+        return nil;
+    }
+
+    SecCertificateRef certificate = NULL;
+    OSStatus status = SecIdentityCopyCertificate(identity, &certificate);
+    if (   (status != errSecSuccess)
+        || (certificate == NULL)  ) {
+        *errMsgPtr = [NSString stringWithFormat:
+                      NSLocalizedString(@"Could not get the certificate from the Keychain (%@).", @"Window text; the '%@' is replaced by a description of an error"),
+                      [self messageForOSStatus: status]];
+        return nil;
+    }
+
+    CFDataRef der = SecCertificateCopyData(certificate);
+    CFRelease(certificate);
+    if (  der == NULL  ) {
+        *errMsgPtr = NSLocalizedString(@"Could not get the contents of the certificate from the Keychain.", @"Window text");
+        return nil;
+    }
+
+    NSString * base64 = [(__bridge NSData *)der base64EncodedStringWithOptions: NSDataBase64Encoding64CharacterLineLength];
+    CFRelease(der);
+
+    if (  [base64 length] == 0  ) {
+        *errMsgPtr = NSLocalizedString(@"Could not encode the certificate from the Keychain.", @"Window text");
+        return nil;
+    }
+
+    // base64EncodedStringWithOptions inserts CR-LF; OpenVPN wants the PEM as separate lines
+    base64 = [base64 stringByReplacingOccurrencesOfString: @"\r\n" withString: @"\n"];
+
+    return [NSString stringWithFormat: @"-----BEGIN CERTIFICATE-----\n%@\n-----END CERTIFICATE-----", base64];
+}
+
++(SecKeyAlgorithm) algorithmFromString: (NSString *)  algorithm
+                          errorMessage: (NSString **) errMsgPtr {
+
+    // Translates the algorithm from a '>PK_SIGN:' message into a SecKeyAlgorithm.
+    //
+    // The algorithms that OpenVPN can ask for are documented in OpenVPN's doc/management-notes.txt.
+
+    // The obsolete '>RSA_SIGN:' message does not include an algorithm and always means PKCS#1 v1.5
+    if (  [algorithm length] == 0  ) {
+        return kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw;
+    }
+
+    NSArray  * parameters = [algorithm componentsSeparatedByString: @","];
+    NSString * padding    = [[parameters objectAtIndex: 0] stringByTrimmingCharactersInSet: [NSCharacterSet whitespaceCharacterSet]];
+
+    if (  [padding isEqualToString: @"RSA_PKCS1_PADDING"]  ) {
+        // OpenVPN has already prepended the DigestInfo header, so the digest algorithm is not specified here
+        return kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw;
+    }
+
+    if (  [padding isEqualToString: @"RSA_NO_PADDING"]  ) {
+        return kSecKeyAlgorithmRSASignatureRaw;
+    }
+
+    if (  [padding isEqualToString: @"ECDSA"]  ) {
+        // Produces the DER-encoded (r, s) signature that OpenVPN expects
+        return kSecKeyAlgorithmECDSASignatureDigestX962;
+    }
+
+    if (  [padding isEqualToString: @"RSA_PKCS1_PSS_PADDING"]  ) {
+
+        NSString * hashAlgorithm = nil;
+        NSString * saltLength    = nil;
+
+        NSUInteger ix;
+        for (  ix=1; ix<[parameters count]; ix++  ) {
+            NSString * parameter = [[parameters objectAtIndex: ix] stringByTrimmingCharactersInSet: [NSCharacterSet whitespaceCharacterSet]];
+            if (  [parameter hasPrefix: @"hashalg="]  ) {
+                hashAlgorithm = [[parameter substringFromIndex: [@"hashalg=" length]] uppercaseString];
+            } else if (  [parameter hasPrefix: @"saltlen="]  ) {
+                saltLength = [parameter substringFromIndex: [@"saltlen=" length]];
+            }
+        }
+
+        // The Security framework always uses a salt whose length is the length of the digest
+        if (   (saltLength != nil)
+            && ( ! [saltLength isEqualToString: @"digest"])  ) {
+            *errMsgPtr = [NSString stringWithFormat:
+                          NSLocalizedString(@"OpenVPN asked for a PSS signature with a salt length of '%@', which macOS cannot create.", @"Window text; the '%@' is replaced by the name of a salt length"),
+                          saltLength];
+            return NULL;
+        }
+
+        if (  [hashAlgorithm isEqualToString: @"SHA256"]  ) {
+            return kSecKeyAlgorithmRSASignatureDigestPSSSHA256;
+        }
+        if (  [hashAlgorithm isEqualToString: @"SHA384"]  ) {
+            return kSecKeyAlgorithmRSASignatureDigestPSSSHA384;
+        }
+        if (  [hashAlgorithm isEqualToString: @"SHA512"]  ) {
+            return kSecKeyAlgorithmRSASignatureDigestPSSSHA512;
+        }
+        if (  [hashAlgorithm isEqualToString: @"SHA224"]  ) {
+            return kSecKeyAlgorithmRSASignatureDigestPSSSHA224;
+        }
+        if (  [hashAlgorithm isEqualToString: @"SHA1"]  ) {
+            return kSecKeyAlgorithmRSASignatureDigestPSSSHA1;
+        }
+
+        *errMsgPtr = [NSString stringWithFormat:
+                      NSLocalizedString(@"OpenVPN asked for a PSS signature using the '%@' hash, which Tunnelblick does not support.", @"Window text; the '%@' is replaced by the name of a hash algorithm"),
+                      (  hashAlgorithm ? hashAlgorithm : @"(not specified)")];
+        return NULL;
+    }
+
+    *errMsgPtr = [NSString stringWithFormat:
+                  NSLocalizedString(@"OpenVPN asked for a signature using '%@', which Tunnelblick does not support.", @"Window text; the '%@' is replaced by the name of a signature algorithm"),
+                  algorithm];
+    return NULL;
+}
+
++(NSData *) signData: (NSData *)       data
+        withIdentity: (SecIdentityRef) identity
+           algorithm: (NSString *)     algorithm
+        errorMessage: (NSString **)    errMsgPtr {
+
+    if (  identity == NULL  ) {
+        *errMsgPtr = NSLocalizedString(@"No Keychain certificate has been selected.", @"Window text");
+        return nil;
+    }
+
+    if (  [data length] == 0  ) {
+        *errMsgPtr = NSLocalizedString(@"OpenVPN asked Tunnelblick to sign nothing.", @"Window text");
+        return nil;
+    }
+
+    SecKeyAlgorithm secAlgorithm = [self algorithmFromString: algorithm errorMessage: errMsgPtr];
+    if (  secAlgorithm == NULL  ) {
+        return nil;
+    }
+
+    SecKeyRef privateKey = NULL;
+    OSStatus status = SecIdentityCopyPrivateKey(identity, &privateKey);
+    if (   (status != errSecSuccess)
+        || (privateKey == NULL)  ) {
+        *errMsgPtr = [NSString stringWithFormat:
+                      NSLocalizedString(@"Could not get the private key from the Keychain (%@).", @"Window text; the '%@' is replaced by a description of an error"),
+                      [self messageForOSStatus: status]];
+        return nil;
+    }
+
+    if (  ! SecKeyIsAlgorithmSupported(privateKey, kSecKeyOperationTypeSign, secAlgorithm)  ) {
+        *errMsgPtr = [NSString stringWithFormat:
+                      NSLocalizedString(@"The private key in the Keychain cannot create the '%@' signature that OpenVPN asked for.", @"Window text; the '%@' is replaced by the name of a signature algorithm"),
+                      (  [algorithm length] == 0  ? @"RSA_PKCS1_PADDING" : algorithm)];
+        CFRelease(privateKey);
+        return nil;
+    }
+
+    CFErrorRef error = NULL;
+    CFDataRef signature = SecKeyCreateSignature(privateKey, secAlgorithm, (__bridge CFDataRef)data, &error);
+    CFRelease(privateKey);
+
+    if (  signature == NULL  ) {
+        *errMsgPtr = [NSString stringWithFormat:
+                      NSLocalizedString(@"Could not sign data with the private key in the Keychain (%@).", @"Window text; the '%@' is replaced by a description of an error"),
+                      [self messageForCFError: error]];
+        if (  error != NULL  ) {
+            CFRelease(error);
+        }
+        return nil;
+    }
+
+    if (  error != NULL  ) {
+        CFRelease(error);
+    }
+
+    NSData * result = [[(__bridge NSData *)signature copy] autorelease];
+    CFRelease(signature);
+
+    return result;
+}
+
+@end

--- a/tunnelblick/TBKeychainIdentityTest.m
+++ b/tunnelblick/TBKeychainIdentityTest.m
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2026 Andrew Grishenko. All rights reserved.
+ *
+ *  This file is part of Tunnelblick.
+ *
+ *  Tunnelblick is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  Tunnelblick is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, see http://www.gnu.org/licenses/.
+ */
+
+// A command line program that exercises TBKeychainIdentity against the Keychain of the user that runs it,
+// so that the selection of a certificate and the creation of signatures can be tested without connecting
+// to a VPN. It is not part of the Tunnelblick application; build and run it with:
+//
+//      cd tunnelblick
+//      clang -fno-objc-arc -mmacosx-version-min=13.0 -framework Foundation -framework Security \
+//            -o /tmp/tbkeychainidentitytest TBKeychainIdentity.m TBKeychainIdentityTest.m
+//      /tmp/tbkeychainidentitytest 'SUBJ:CN=someone'
+//
+// For each signature algorithm that OpenVPN can ask for, the program creates a signature and verifies it
+// with the certificate's public key.
+
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
+#import <CommonCrypto/CommonDigest.h>
+
+#import "TBKeychainIdentity.h"
+
+// TBKeychainIdentity logs via appendLog(), which is part of the Tunnelblick application
+void appendLog(NSString * msg) {
+    fprintf(stderr, "    log: %s\n", [msg UTF8String]);
+}
+
+static BOOL anythingFailed = NO;
+
+static void report(NSString * name, BOOL ok, NSString * detail) {
+
+    fprintf(stdout, "%s %-46s %s\n",
+            (ok ? "ok  " : "FAIL"),
+            [name UTF8String],
+            [(detail ? detail : @"") UTF8String]);
+    if (  ! ok  ) {
+        anythingFailed = YES;
+    }
+}
+
+static NSData * sha256OfString(NSString * string) {
+
+    NSData * data = [string dataUsingEncoding: NSUTF8StringEncoding];
+    unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256([data bytes], (CC_LONG)[data length], digest);
+    return [NSData dataWithBytes: digest length: sizeof(digest)];
+}
+
+static NSData * digestInfoForSha256(NSData * digest) {
+
+    // The DigestInfo header for SHA-256 that OpenVPN prepends before asking for a PKCS#1 v1.5 signature
+    static const unsigned char prefix[] = {
+        0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01,
+        0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20
+    };
+
+    NSMutableData * digestInfo = [NSMutableData dataWithBytes: prefix length: sizeof(prefix)];
+    [digestInfo appendData: digest];
+    return digestInfo;
+}
+
+static SecKeyRef copyPublicKeyOfIdentity(SecIdentityRef identity) {
+
+    SecCertificateRef certificate = NULL;
+    if (   (SecIdentityCopyCertificate(identity, &certificate) != errSecSuccess)
+        || (certificate == NULL)  ) {
+        return NULL;
+    }
+
+    SecKeyRef publicKey = SecCertificateCopyKey(certificate);
+    CFRelease(certificate);
+    return publicKey;
+}
+
+static void testAlgorithm(SecIdentityRef  identity,
+                          SecKeyRef       publicKey,
+                          NSString *      algorithm,
+                          NSData *        dataToSign,
+                          SecKeyAlgorithm verifyAlgorithm) {
+
+    NSString * errMsg = nil;
+    NSData * signature = [TBKeychainIdentity signData: dataToSign
+                                        withIdentity: identity
+                                           algorithm: algorithm
+                                        errorMessage: &errMsg];
+    if (  signature == nil  ) {
+        report(algorithm, NO, errMsg);
+        return;
+    }
+
+    if (  verifyAlgorithm == NULL  ) {
+        report(algorithm, YES, [NSString stringWithFormat: @"%lu-byte signature (not verified)", (unsigned long)[signature length]]);
+        return;
+    }
+
+    CFErrorRef error = NULL;
+    BOOL verified = SecKeyVerifySignature(publicKey,
+                                          verifyAlgorithm,
+                                          (__bridge CFDataRef)dataToSign,
+                                          (__bridge CFDataRef)signature,
+                                          &error);
+    NSString * detail = (  verified
+                         ? [NSString stringWithFormat: @"%lu-byte signature verified", (unsigned long)[signature length]]
+                         : [(__bridge NSError *)error localizedDescription]);
+    if (  error != NULL  ) {
+        CFRelease(error);
+    }
+
+    report(algorithm, verified, detail);
+}
+
+static int listAllIdentities(void) {
+
+    // Lists every identity in the Keychain without using any private key, so it does not ask the user for
+    // permission to use a key.
+
+    NSDictionary * query = [NSDictionary dictionaryWithObjectsAndKeys:
+                            (__bridge id)kSecClassIdentity, (__bridge id)kSecClass,
+                            (__bridge id)kSecMatchLimitAll, (__bridge id)kSecMatchLimit,
+                            (id)kCFBooleanTrue,             (__bridge id)kSecReturnRef,
+                            nil];
+
+    CFTypeRef result = NULL;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &result);
+    if (  status == errSecItemNotFound  ) {
+        fprintf(stdout, "There are no identities (certificates with private keys) in the Keychain.\n");
+        return 0;
+    }
+    if (   (status != errSecSuccess)
+        || (result == NULL)  ) {
+        fprintf(stderr, "Could not search the Keychain: status = %d\n", (int)status);
+        return 1;
+    }
+
+    NSArray * identities = (__bridge NSArray *)result;
+    fprintf(stdout, "%lu identities in the Keychain:\n", (unsigned long)[identities count]);
+    NSUInteger ix;
+    for (  ix=0; ix<[identities count]; ix++  ) {
+        SecIdentityRef identity = (SecIdentityRef)[identities objectAtIndex: ix];
+        NSString * description = [TBKeychainIdentity descriptionForIdentity: identity];
+        fprintf(stdout, "    %s\n", [(description ? description : @"(could not be described)") UTF8String]);
+    }
+    CFRelease(result);
+
+    return 0;
+}
+
+int main(int argc, const char * argv[]) {
+
+    @autoreleasepool {
+
+        if (  argc == 1  ) {
+            return listAllIdentities();
+        }
+
+        if (   (argc < 2)
+            || (argc > 3)
+            || (   (argc == 3)
+                && (strcmp(argv[2], "--no-sign") != 0))  ) {
+            fprintf(stderr, "Usage: %s [<selector> [--no-sign]]\n"
+                            "   with no arguments, lists all identities in the Keychain\n"
+                            "   for example: %s 'SUBJ:CN=someone'\n"
+                            "                %s 'THUMB:a1b2c3...'\n"
+                            "                %s 'ISSUER:Example CA'\n"
+                            "   '--no-sign' stops after getting the certificate, so no private key is used\n",
+                    argv[0], argv[0], argv[0], argv[0]);
+            return 2;
+        }
+
+        BOOL signingIsWanted = (argc == 2);
+
+        NSString * selector = [NSString stringWithUTF8String: argv[1]];
+
+        NSString * errMsg = nil;
+        SecIdentityRef identity = [TBKeychainIdentity copyIdentityMatchingSelector: selector errorMessage: &errMsg];
+        if (  identity == NULL  ) {
+            report(@"find identity", NO, errMsg);
+            return 1;
+        }
+        report(@"find identity", YES, [TBKeychainIdentity descriptionForIdentity: identity]);
+
+        NSString * pem = [TBKeychainIdentity pemForIdentity: identity errorMessage: &errMsg];
+        BOOL pemIsOK = (   (pem != nil)
+                        && [pem hasPrefix: @"-----BEGIN CERTIFICATE-----\n"]
+                        && [pem hasSuffix: @"\n-----END CERTIFICATE-----"]
+                        && ([pem rangeOfString: @"\r"].length == 0));
+        NSString * pemDetail = (  pemIsOK
+                                ? [NSString stringWithFormat: @"%lu characters", (unsigned long)[pem length]]
+                                : errMsg);
+
+        if (  pemIsOK  ) {
+
+            // Parse the PEM back into a certificate, the way OpenVPN will, and make sure it is the same
+            // certificate that we started with
+            NSString * body = [pem substringWithRange: NSMakeRange([@"-----BEGIN CERTIFICATE-----\n" length],
+                                                                   [pem length] - [@"-----BEGIN CERTIFICATE-----\n" length] - [@"\n-----END CERTIFICATE-----" length])];
+            NSData * der = [[[NSData alloc] initWithBase64EncodedString: body
+                                                               options: NSDataBase64DecodingIgnoreUnknownCharacters] autorelease];
+            SecCertificateRef parsed = (  der
+                                        ? SecCertificateCreateWithData(NULL, (__bridge CFDataRef)der)
+                                        : NULL);
+            if (  parsed == NULL  ) {
+                pemIsOK = NO;
+                pemDetail = @"the PEM could not be parsed back into a certificate";
+            } else {
+                CFStringRef summaryCF = SecCertificateCopySubjectSummary(parsed);
+                NSString * parsedSummary = (  summaryCF
+                                            ? [[(__bridge NSString *)summaryCF copy] autorelease]
+                                            : @"(no subject summary)");
+                if (  summaryCF != NULL  ) {
+                    CFRelease(summaryCF);
+                }
+                CFRelease(parsed);
+                pemDetail = [NSString stringWithFormat: @"%@, parses back to '%@'", pemDetail, parsedSummary];
+            }
+        }
+
+        report(@"certificate as PEM", pemIsOK, pemDetail);
+
+        // Algorithms that OpenVPN will not ask for must be rejected instead of creating a wrong signature.
+        // These are checked before the private key is used, so they do not ask the user for permission.
+        NSData * digest = sha256OfString(@"Tunnelblick TBKeychainIdentity test data");
+
+        errMsg = nil;
+        NSData * signature = [TBKeychainIdentity signData: digest
+                                             withIdentity: identity
+                                                algorithm: @"RSA_PKCS1_PSS_PADDING,hashalg=SHA256,saltlen=max"
+                                             errorMessage: &errMsg];
+        report(@"reject saltlen=max", (signature == nil), errMsg);
+
+        errMsg = nil;
+        signature = [TBKeychainIdentity signData: digest
+                                    withIdentity: identity
+                                       algorithm: @"NO_SUCH_PADDING"
+                                    errorMessage: &errMsg];
+        report(@"reject unknown algorithm", (signature == nil), errMsg);
+
+        if (  ! signingIsWanted  ) {
+            CFRelease(identity);
+            return (anythingFailed ? 1 : 0);
+        }
+
+        SecKeyRef publicKey = copyPublicKeyOfIdentity(identity);
+        if (  publicKey == NULL  ) {
+            report(@"get public key", NO, @"could not get the public key from the certificate");
+            CFRelease(identity);
+            return 1;
+        }
+
+        if (  SecKeyIsAlgorithmSupported(publicKey, kSecKeyOperationTypeVerify, kSecKeyAlgorithmECDSASignatureDigestX962)  ) {
+
+            testAlgorithm(identity, publicKey, @"ECDSA", digest, kSecKeyAlgorithmECDSASignatureDigestX962);
+
+        } else {
+
+            testAlgorithm(identity, publicKey, @"RSA_PKCS1_PADDING", digestInfoForSha256(digest),
+                          kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw);
+
+            testAlgorithm(identity, publicKey, @"RSA_PKCS1_PSS_PADDING,hashalg=SHA256,saltlen=digest", digest,
+                          kSecKeyAlgorithmRSASignatureDigestPSSSHA256);
+
+            // OpenVPN pads the data itself for RSA_NO_PADDING, so the input is as long as the key and the
+            // result cannot be verified with a padding-aware algorithm
+            NSUInteger keySizeInBytes = SecKeyGetBlockSize(publicKey);
+            NSMutableData * rawData = [NSMutableData dataWithLength: keySizeInBytes];
+            [rawData replaceBytesInRange: NSMakeRange(keySizeInBytes - [digest length], [digest length])
+                               withBytes: [digest bytes]];
+            testAlgorithm(identity, publicKey, @"RSA_NO_PADDING", rawData, NULL);
+        }
+
+        CFRelease(publicKey);
+        CFRelease(identity);
+    }
+
+    return (anythingFailed ? 1 : 0);
+}

--- a/tunnelblick/Tunnelblick.xcodeproj/project.pbxproj
+++ b/tunnelblick/Tunnelblick.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		63C79A292ECB5B9100B7BDCA /* UpdateSigning.m in Sources */ = {isa = PBXBuildFile; fileRef = 63372B082EC79472004E5014 /* UpdateSigning.m */; };
 		63C79A2A2ECB5B9F00B7BDCA /* UpdateSigning.m in Sources */ = {isa = PBXBuildFile; fileRef = 63372B082EC79472004E5014 /* UpdateSigning.m */; };
 		63C79A2B2ECB5BB200B7BDCA /* UpdateSigning.m in Sources */ = {isa = PBXBuildFile; fileRef = 63372B082EC79472004E5014 /* UpdateSigning.m */; };
+		63C7A1122F1A000100AA0003 /* TBKeychainIdentity.m in Sources */ = {isa = PBXBuildFile; fileRef = 63C7A1112F1A000100AA0002 /* TBKeychainIdentity.m */; };
 		63C98A732913D6A700DB78F2 /* KK.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 63C98A722913D6A700DB78F2 /* KK.lproj */; };
 		63CC72F91928C5CB00F81220 /* TBUIUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 63CC72F81928C5CB00F81220 /* TBUIUpdater.m */; };
 		63D2658829940ACC00E1C3FF /* HI.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 63D2658729940ACC00E1C3FF /* HI.lproj */; };
@@ -634,6 +635,8 @@
 		63C374391A4510AA00D51E81 /* tunnelblick-helper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "tunnelblick-helper"; sourceTree = BUILT_PRODUCTS_DIR; };
 		63C375781A4510F600D51E81 /* tunnelblick-helper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "tunnelblick-helper.m"; sourceTree = "<group>"; };
 		63C504281178E21100340D13 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		63C7A1102F1A000100AA0001 /* TBKeychainIdentity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TBKeychainIdentity.h; sourceTree = "<group>"; };
+		63C7A1112F1A000100AA0002 /* TBKeychainIdentity.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TBKeychainIdentity.m; sourceTree = "<group>"; };
 		63C98A722913D6A700DB78F2 /* KK.lproj */ = {isa = PBXFileReference; lastKnownFileType = folder; path = KK.lproj; sourceTree = "<group>"; };
 		63CC72F71928C5CB00F81220 /* TBUIUpdater.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TBUIUpdater.h; sourceTree = "<group>"; };
 		63CC72F81928C5CB00F81220 /* TBUIUpdater.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TBUIUpdater.m; sourceTree = "<group>"; };
@@ -889,6 +892,8 @@
 				61BC4B6A0E2F9EBC00F24255 /* MenuController.m */,
 				61BC4B6B0E2F9EBC00F24255 /* NetSocket.h */,
 				61BC4B6C0E2F9EBC00F24255 /* NetSocket.m */,
+				63C7A1102F1A000100AA0001 /* TBKeychainIdentity.h */,
+				63C7A1112F1A000100AA0002 /* TBKeychainIdentity.m */,
 				61BC4B650E2F9EBC00F24255 /* VPNConnection.h */,
 				61BC4B660E2F9EBC00F24255 /* VPNConnection.m */,
 			);
@@ -2165,6 +2170,7 @@
 				63FFD6581D0E9D9400D4FFD9 /* SystemAuth.m in Sources */,
 				6395C2321E37B90000E3C176 /* TBButton.m in Sources */,
 				639DF6112BDD4DE80099921A /* TBDownloader.m in Sources */,
+				63C7A1122F1A000100AA0003 /* TBKeychainIdentity.m in Sources */,
 				6372CDCA1BFCCBC500FC04DC /* TBOperationQueue.m in Sources */,
 				B82DF4D8182704D800A121DE /* TBPerformer.m in Sources */,
 				631BC4311FC4496300730786 /* TBPopUpButton.m in Sources */,

--- a/tunnelblick/VPNConnection.h
+++ b/tunnelblick/VPNConnection.h
@@ -105,7 +105,11 @@ struct Statistics {
 	NSString      * authRetryParameter;		// Parameter from auth-retry as seen in configuration file (or nil if not seen)
 	
     NSString     * managementPassword;
-    
+
+	SecIdentityRef keychainIdentity;	// NULL, or the Keychain identity (certificate and private key) that is being used
+	//									// for this connection because the configuration includes the OpenVPN
+	//									// 'management-external-cert' option. Set when OpenVPN asks for the certificate.
+
 	pid_t           pid;                // 0, or process ID of OpenVPN process created for this connection
 	unsigned int    portNumber;         // 0, or port number used to connect to management socket
     volatile int32_t avoidHasDisconnectedDeadlock; // See note at start of 'hasDisconnected' method

--- a/tunnelblick/VPNConnection.m
+++ b/tunnelblick/VPNConnection.m
@@ -46,6 +46,7 @@
 #import "StatusWindowController.h"
 #import "SystemAuth.h"
 #import "TunnelblickInfo.h"
+#import "TBKeychainIdentity.h"
 #import "TBOperationQueue.h"
 #import "TBUserDefaults.h"
 #import "UIHelper.h"
@@ -86,6 +87,8 @@ extern NSArray          * gTotalUnits;
 
 -(BOOL)             hasLaunchDaemon;
 
+-(void)             keychainIdentityFailure:    (NSString *)        message;
+
 -(void)             killProcess;    // Kills the OpenVPN process associated with this connection, if any
 
 -(NSString * )      leasewatchOptionsFromPreferences;
@@ -96,11 +99,18 @@ extern NSArray          * gTotalUnits;
 
 -(void)             processLine:                (NSString *)        line;
 
+-(void)             processNeedCertificateWithParameterString: (NSString *) parameterString;
+
+-(void)             processPkSignWithParameterString: (NSString *)   parameterString
+                                             command: (NSString *)   command;
+
 -(void)             processState:               (NSString *)        newState
                            dated:               (NSString *)        dateTime;
 
 -(void)             provideCredentials:         (NSString *)        parameterString
                                   line:         (NSString *)        line;
+
+-(void)             releaseKeychainIdentity;
 
 -(void)             runScriptNamed:             (NSString *)        scriptName
                openvpnstartCommand:             (NSString *)        command;
@@ -121,6 +131,8 @@ extern NSArray          * gTotalUnits;
                               key:              (NSString *)        key;
 
 -(NSString *)       timeString;
+
+-(BOOL)             usesManagementExternalKey;
 
 TBPROPERTY(          NSMutableArray *,         messagesIfConnectionFails,        setMessagesIfConnectionFails)
 
@@ -345,6 +357,28 @@ TBPROPERTY(          NSMutableArray *,         messagesIfConnectionFails,       
     }
 
     return NO;
+}
+
+-(BOOL) usesManagementExternalKey {
+
+    // Returns TRUE iff the configuration uses OpenVPN's 'management-external-key' option, which means that
+    // Tunnelblick must supply the certificate and/or create signatures via the management interface.
+
+    NSString * cfgContents = [self condensedSanitizedConfigurationFileContents];
+    if (  cfgContents  ) {
+        return (nil != [ConfigurationManager parseString: cfgContents forOption: @"management-external-key"]);
+    }
+
+    NSLog(@"Unable to obtain configuration file for %@", [self displayName]);
+    return NO;
+}
+
+-(void) releaseKeychainIdentity {
+
+    if (  keychainIdentity != NULL  ) {
+        CFRelease(keychainIdentity);
+        keychainIdentity = NULL;
+    }
 }
 
 -(void) tryToHookup: (NSDictionary *) dict {
@@ -997,6 +1031,8 @@ TBPROPERTY(          NSMutableArray *,         messagesIfConnectionFails,       
     [dynamicChallengeFlags            release]; dynamicChallengeFlags            = nil;
     [authRetryParameter				  release]; authRetryParameter               = nil;
     [managementPassword               release]; managementPassword               = nil;
+
+	[self releaseKeychainIdentity];
 
     [super dealloc];
 }
@@ -3205,6 +3241,9 @@ ifConnectionPreference: (NSString *)     keySuffix
         [managementSocket release];
         managementSocket = nil;
     }
+
+	// Do not hold on to the Keychain identity (and thus to the private key) after the connection ends
+	[self releaseKeychainIdentity];
 }
 
 -(void) cancelDisplayOfSlowDisconnectionDialog {
@@ -3627,8 +3666,21 @@ static pthread_mutex_t lastStateMutex = PTHREAD_MUTEX_INITIALIZER;
 									   ? @"auth-retry interact\r\n"
 									   : nil);
 
+		// If OpenVPN will ask us to create signatures, tell it that we understand version 3 of the management
+		// interface, so that its '>PK_SIGN' messages include the signature algorithm. (Without that, OpenVPN
+		// sends the obsolete '>RSA_SIGN' message, which cannot be used with TLS 1.3.)
+		//
+		// Do this only for such configurations: versions higher than 3 change how OpenVPN asks for usernames
+		// and passwords, and version 3 is the highest version that does not change any of that.
+		NSString * versionCommand = (  [self usesManagementExternalKey]
+									 ? @"version 3\r\n"
+									 : nil);
+
 		NS_DURING {
 			[managementSocket writeString: [password stringByAppendingString: @"\r\n"] encoding: NSASCIIStringEncoding];
+			if (  versionCommand  ) {
+				[managementSocket writeString: versionCommand			encoding: NSASCIIStringEncoding];
+			}
 			[managementSocket writeString: @"pid\r\n"					encoding: NSASCIIStringEncoding];
 			if (  authRetryCommand  ) {
 				[managementSocket writeString: authRetryCommand			encoding: NSASCIIStringEncoding];
@@ -4493,6 +4545,135 @@ static pthread_mutex_t lastStateMutex = PTHREAD_MUTEX_INITIALIZER;
     }
 }
 
+-(void) keychainIdentityFailure: (NSString *) message {
+
+	// Called when we cannot do what OpenVPN asked us to do with the Keychain identity. OpenVPN is waiting for
+	// a response that we cannot provide, so tell the user what happened and disconnect.
+
+	NSLog(@"%@: %@", [self displayName], message);
+	[self addToLog: [NSString stringWithFormat: @"*Tunnelblick: %@", message]];
+	[self addMessageToDisplayIfConnectionFails: message];
+
+	TBShowAlertWindow([NSString stringWithFormat: @"%@: %@",
+					   [self localizedName],
+					   NSLocalizedString(@"Tunnelblick Error", @"Window title")],
+					  message);
+
+	[self sendSigtermToManagementSocket];
+}
+
+-(void) processNeedCertificateWithParameterString: (NSString *) parameterString {
+
+	// OpenVPN's 'management-external-cert' option is being used, and OpenVPN wants the certificate. The
+	// parameter string is the option's argument, which specifies which Keychain identity to use.
+	//
+	// The response is the certificate as PEM, which OpenVPN parses as if it had been included inline in the
+	// configuration file.
+
+	[self releaseKeychainIdentity];
+
+	NSString * errMsg = nil;
+	SecIdentityRef identity = [TBKeychainIdentity copyIdentityMatchingSelector: parameterString errorMessage: &errMsg];
+	if (  identity == NULL  ) {
+		[self keychainIdentityFailure:
+		 [NSString stringWithFormat:
+		  NSLocalizedString(@"Could not get a certificate from the Keychain: %@", @"Window text; the '%@' is replaced by a description of an error"),
+		  errMsg]];
+		return;
+	}
+
+	NSString * pem = [TBKeychainIdentity pemForIdentity: identity errorMessage: &errMsg];
+	if (  pem == nil  ) {
+		CFRelease(identity);
+		[self keychainIdentityFailure:
+		 [NSString stringWithFormat:
+		  NSLocalizedString(@"Could not get a certificate from the Keychain: %@", @"Window text; the '%@' is replaced by a description of an error"),
+		  errMsg]];
+		return;
+	}
+
+	keychainIdentity = identity;
+
+	[self addToLog: [NSString stringWithFormat: @"*Tunnelblick: Using the certificate from the Keychain: %@",
+					 [TBKeychainIdentity descriptionForIdentity: identity]]];
+
+	[self sendStringToManagementSocket: [NSString stringWithFormat: @"certificate\r\n%@\r\nEND\r\n",
+										[pem stringByReplacingOccurrencesOfString: @"\n" withString: @"\r\n"]]
+							 encoding: NSASCIIStringEncoding];
+}
+
+-(void) processPkSignWithParameterString: (NSString *) parameterString
+								 command: (NSString *) command {
+
+	// OpenVPN's 'management-external-key' option is being used, and OpenVPN wants us to sign data with the
+	// private key of the Keychain identity that we supplied the certificate for.
+	//
+	// The parameter string is the base64-encoded data to sign, optionally followed by a comma and the
+	// signature algorithm to use. (The obsolete 'RSA_SIGN' command never includes an algorithm.)
+
+	NSString * base64Data = parameterString;
+	NSString * algorithm  = nil;
+	NSRange commaRange = [parameterString rangeOfString: @","];
+	if (  commaRange.length != 0  ) {
+		base64Data = [parameterString substringToIndex: commaRange.location];
+		algorithm  = [parameterString substringFromIndex: commaRange.location + 1];
+	}
+
+	NSData * data = [[[NSData alloc] initWithBase64EncodedString: base64Data
+														 options: NSDataBase64DecodingIgnoreUnknownCharacters] autorelease];
+	if (  [data length] == 0  ) {
+		[self keychainIdentityFailure:
+		 NSLocalizedString(@"OpenVPN asked Tunnelblick to create a signature but did not provide valid data to sign.", @"Window text")];
+		return;
+	}
+
+	if (  keychainIdentity == NULL  ) {
+		[self keychainIdentityFailure:
+		 NSLocalizedString(@"OpenVPN asked Tunnelblick to create a signature, but no Keychain certificate is being used for this connection.", @"Window text")];
+		return;
+	}
+
+	// Signing may require the user to allow access to the private key, which can take an arbitrary amount of
+	// time, so do it on another thread and send the response back on the main thread.
+	SecIdentityRef identity = (SecIdentityRef)CFRetain(keychainIdentity);
+	NSString * responseCommand = (  [command isEqualToString: @"RSA_SIGN"]
+								  ? @"rsa-sig"
+								  : @"pk-sig");
+
+	dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+
+		@autoreleasepool {
+
+			NSString * signErrMsg = nil;
+			NSData * signature = [TBKeychainIdentity signData: data
+												 withIdentity: identity
+													algorithm: algorithm
+												 errorMessage: &signErrMsg];
+			CFRelease(identity);
+
+			// OpenVPN reads the response one line at a time into a 1024-byte buffer, which is large enough
+			// for the base64 of a signature made with a key of up to 6144 bits, so send it as a single line
+			NSString * base64Signature = (  signature
+										  ? [signature base64EncodedStringWithOptions: 0]
+										  : nil);
+
+			dispatch_async(dispatch_get_main_queue(), ^{
+
+				if (  base64Signature == nil  ) {
+					[self keychainIdentityFailure:
+					 [NSString stringWithFormat:
+					  NSLocalizedString(@"Could not create a signature using the private key in the Keychain: %@", @"Window text; the '%@' is replaced by a description of an error"),
+					  signErrMsg]];
+					return;
+				}
+
+				[self sendStringToManagementSocket: [NSString stringWithFormat: @"%@\r\n%@\r\nEND\r\n", responseCommand, base64Signature]
+										  encoding: NSASCIIStringEncoding];
+			});
+		}
+	});
+}
+
 -(void) processNeedOkWithLine: (NSString *) line parameterString: (NSString *) parameterString {
 
     // NEED-OK: MSG:Please insert TOKEN
@@ -4673,6 +4854,13 @@ static pthread_mutex_t lastStateMutex = PTHREAD_MUTEX_INITIALIZER;
 
     } else if (  [command isEqualToString: @"NEED-OK"]) {
         [self processNeedOkWithLine: line parameterString: parameterString];
+
+    } else if (  [command isEqualToString: @"NEED-CERTIFICATE"]  ) {
+        [self processNeedCertificateWithParameterString: parameterString];
+
+    } else if (   [command isEqualToString: @"PK_SIGN"]
+			   || [command isEqualToString: @"RSA_SIGN"]  ) {
+        [self processPkSignWithParameterString: parameterString command: command];
 
     } else if (  [command isEqualToString: @"INFO"]) {
         [self addToLog: line];


### PR DESCRIPTION
### What this does

On Windows a configuration can keep the certificate and the private key in the system store and refer to them with `cryptoapicert "SUBJ:…"`. On macOS there is no equivalent: `cryptoapicert` is Windows-only (and Tunnelblick rejects it), and the OpenVPN binaries that Tunnelblick includes are built with `enable_pkcs11=no`, so PKCS#11 is not available either. That leaves keeping the certificate and the private key in a file inside the configuration.

This implements the remaining alternative: OpenVPN's `--management-external-cert` and `--management-external-key`, answered by Tunnelblick as the management client. The certificate and the private key stay in the user's login keychain, and the configuration contains only a selector:

```
management-external-cert "SUBJ:CN=my name"
management-external-key pkcs1 pss nopadding
```

Both options are already in `OPENVPN_OPTIONS_THAT_ARE_SAFE`, so nothing about configuration validation changes. What was missing was handling of the `>NEED-CERTIFICATE` and `>PK_SIGN` messages.

### How it works

* When the management socket is connected and the configuration includes `management-external-key`, Tunnelblick sends `version 3` before `pid`. Version 3 is what makes OpenVPN include the signature algorithm in `>PK_SIGN`; without it OpenVPN uses the obsolete `>RSA_SIGN`, which carries no algorithm and cannot be used with TLS 1.3. It is sent *only* for those configurations, and it is version 3 rather than something higher on purpose: `MCV_USERNAME_ONLY` (4) and `MCV_MULTILINE_PASSWORD` (5) change the format of the username and password requests, which would change behavior for every other configuration.
* `>NEED-CERTIFICATE:<selector>` → find the identity in the Keychain and answer with the certificate as PEM. The answer has to be a full PEM including the armor lines, not the bare base64 that `doc/management-notes.txt` describes: OpenVPN hands it to `tls_ctx_load_cert_file(…, inline = true)`, i.e. to the PEM parser. Only the certificate itself is sent; an intermediate CA, if there is one, goes into the configuration as `<extra-certs>`.
* `>PK_SIGN:<base64>[,<algorithm>]`, and the legacy `>RSA_SIGN:`, → sign with `SecKeyCreateSignature` and answer with `pk-sig` (`rsa-sig` for the legacy message). Signing is done off the main thread, because using the private key may present a Keychain dialog and wait for the user; the response is written to the socket back on the main thread. The base64 of a signature made with a key of up to 6144 bits fits in the 1024-byte line buffer OpenVPN reads the response with, so it is sent as a single line.
* If anything fails — no matching certificate, an algorithm macOS cannot produce, the user denies access to the key — the reason goes to the log and to an alert, and OpenVPN is sent a SIGTERM instead of being left waiting for a response it will never get.
* The identity, and with it the reference to the private key, is released when the management socket goes away.

### The selector

The syntax mirrors `cryptoapicert`, so a configuration can be moved between Windows and macOS by changing only the option name:

| Selector | Matches |
| --- | --- |
| `SUBJ:<string>` | certificate whose subject DN contains `<string>` (case-insensitive) |
| `ISSUER:<string>` | certificate whose issuer DN contains `<string>` (case-insensitive) |
| `THUMB:<hex>` | certificate whose SHA-1 fingerprint is `<hex>` (spaces and colons ignored) |
| `<string>` | the same as `SUBJ:<string>` |

Certificates that are not valid at the current time are skipped. If several identities match, the one with the latest `notBefore` is used and all of the matches are written to the log, so the ambiguity is visible. There is no GUI for choosing a certificate.

Signature algorithms: `RSA_PKCS1_PADDING`, `RSA_NO_PADDING`, `ECDSA`, and `RSA_PKCS1_PSS_PADDING` with `hashalg=SHA1/SHA224/SHA256/SHA384/SHA512`. `saltlen=max` is refused with an explanatory message, because the Security framework can only produce a salt as long as the digest — which is what OpenSSL asks for in TLS 1.3, so in practice it does not come up.

### Files

* `tunnelblick/TBKeychainIdentity.{h,m}` (new) — everything that touches the Keychain and the crypto, with no UI dependencies. Every `Sec*`/`CF*` result is checked and every CF object is released on every path.
* `tunnelblick/VPNConnection.{h,m}` — the conditional `version 3`, two new message handlers, one instance variable, and releasing the identity when the connection ends.
* `tunnelblick/Tunnelblick.xcodeproj/project.pbxproj` — the new files, in the Tunnelblick target only. tunnelblick-helper and openvpnstart do not need them: the Keychain is reached from the user's GUI process.
* `tunnelblick/TBKeychainIdentityTest.m` (new, in a separate commit) — a small command line program that exercises `TBKeychainIdentity` against the Keychain of whoever runs it, without connecting to a VPN. It is not part of any target and is built with the single clang command in its header comment. Happy to drop that commit if you would rather not carry it.

### Testing

Tested on macOS 26.5.2 with Tunnelblick built from 9.0beta06 plus this change, using the OpenVPN that Tunnelblick includes, against an OpenVPN 2.7 server that requires `tls-version-min 1.3`:

* an RSA identity in the login keychain, selected with `management-external-cert "SUBJ:CN=…"`: OpenVPN asked for a PSS signature, the handshake completed and the tunnel came up, with `>NEED-CERTIFICATE` and `>PK_SIGN` and the answers to them visible in the log;
* a TLS renegotiation in the middle of that session: OpenVPN asked for another signature on the same connection, it was created from the identity that was still held for the connection, and the tunnel stayed up;
* the command line program from the second commit: `SUBJ:`, `ISSUER:` and `THUMB:` matching, including a fingerprint written with colons and in mixed case, an empty selector and a selector that matches nothing, plus a signature created and then verified with the certificate's public key for each of the algorithms above;
* configurations that do not use `management-external-key` are unaffected: `version 3` is not sent for them, so the management dialogue for them is unchanged.

