### PR TITLE
fix: wait until launchFinished before installing a config update

### DIFF
--- a/tunnelblick/ConfigurationUpdater.m
+++ b/tunnelblick/ConfigurationUpdater.m
@@ -260,7 +260,7 @@ TBSYNTHESIZE_OBJECT(    retain, NSString *,  feedUrlStringForConfigurationUpdate
             NSLog(@"updaterShouldRelaunchApplication: launchFinished = FALSE but are on the main thread, so not waiting for launchFinished");
         } else {
             // We are not on the main thread, so we make sure that Tunneblick has finished launching and the main thread is ready before we proceed to update the configuration.
-            while (  [gMC launchFinished]  ) {
+            while (  ! [gMC launchFinished]  ) {
                 sleep(1);
             }
         }


### PR DESCRIPTION
Wait until application launch finishes before installing a configuration update.

## Problem

`updaterShouldRelaunchApplication` enters its wait when `launchFinished` is false, then loops `while ([gMC launchFinished])`. That condition is false on entry, so the wait never runs. A configuration update can be installed on a background thread before launch has finished.

This inverted condition has been present since the 2015 wait was added. The 2020 `gMC` refactor kept the same test.

## Change

Invert the loop to `while ( ! [gMC launchFinished] )`.

## Validation

- Inspected the call site and the `launchFinished` setter (`applicationDidFinishLaunching` sets it true).
- After the invert, the wait actually runs, then `installConfigurationsUpdateInBundleAtPathMainThread:` is queued as before.
- Tunnelblick has no unit-test harness for this GUI path (same as #904).

## Related

- Sibling robustness: https://github.com/Tunnelblick/Tunnelblick/pull/904
