### PR TITLE
fix: apply config-name length limit to argv[2]

### DIFF
--- a/tunnelblick/tunnelblick-helper.m
+++ b/tunnelblick/tunnelblick-helper.m
@@ -3223,6 +3223,10 @@ static void validateConfigName(NSString * name) {
         Log(@"Configuration name is empty");
         exitOpenvpnstart(172);
     }
+    if (  [name length] > DISPLAY_NAME_LENGTH_MAX  ) {
+        Log(@"Configuration name is too long");
+        exitOpenvpnstart(175);
+    }
 
     BOOL haveBadChar = FALSE;
 	unsigned i;
@@ -3778,7 +3782,12 @@ int main(int argc, char * argv[]) {
 
 			if (  (argc > 3) && (argc <= OPENVPNSTART_MAX_ARGC)  ) {
 
-                if (  strlen(argv[3]) <= DISPLAY_NAME_LENGTH_MAX                      ) configFile = [NSString stringWithUTF8String:argv[2]];
+                if (  argv[2]  ) {
+                    NSString * parsedConfig = [NSString stringWithUTF8String: argv[2]];
+                    if (  parsedConfig  ) {
+                        configFile = parsedConfig;
+                    }
+                }
                 if (  (argc >  3) && (strlen(argv[ 3]) <  6)                          ) port = cvt_atou(argv[3], @"port");
                 if (  (argc >  4) && (strlen(argv[ 4]) <  6)                          ) useScripts = cvt_atou(argv[4], @"useScripts");
                 if (  (argc >  5) && (strlen(argv[ 5]) <  6) && (atoi(argv[5]) == 1)  ) skipScrSec = TRUE;


### PR DESCRIPTION
Apply the config-name length limit to the actual config argument.

## Problem

The `start` command stored `argv[2]` (the config name) only when `strlen(argv[3])` was under `DISPLAY_NAME_LENGTH_MAX`. `argv[3]` is the port, which is always short when valid, so the name-length gate never ran. `validateConfigName` also did not enforce the 512-character maximum.

## Change

- Assign the config name from `argv[2]` when it is valid UTF-8.
- Reject names longer than `DISPLAY_NAME_LENGTH_MAX` in `validateConfigName` (exit 175).

## Validation

- Traced `start` argument order: config, port, useScripts, ...
- A too-long name now fails validation instead of being ignored while start proceeds with the default `"X"`.
- No helper unit-test harness (same as #904).

## Related

- Sibling robustness: https://github.com/Tunnelblick/Tunnelblick/pull/904
