### PR TITLE
fix: avoid Keychain CFRelease(NULL) and atomic config rewrite

### DIFF
--- a/tunnelblick/ConfigurationConverter.m
+++ b/tunnelblick/ConfigurationConverter.m
@@ -1441,20 +1441,12 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSString *, nameForErrorMessages)
             return [self logMessage: @"Unable to parse configuration file as UTF-8 (#2)"
                           localized: NSLocalizedString(@"Unable to parse configuration file as UTF-8", @"Window text")];
         }
-        FILE * outFile = fopen([configPath fileSystemRepresentation], "w");
-        if (  outFile  ) {
-            size_t numberOfItemsWritten = fwrite(bytes, strlen(bytes), 1, outFile);
-            fclose(outFile);
-			if (  numberOfItemsWritten != 1  ) {
-				return [self logMessage: @"Unable to write to configuration file for modification"
-                              localized: NSLocalizedString(@"Unable to write to configuration file for modification", @"Window text")];
-			}
-			
+        if (  [configString writeToFile: configPath atomically: YES encoding: NSUTF8StringEncoding error: NULL]  ) {
 			[self logMessage: @"Modified configuration file to remove path information"
                    localized: NSLocalizedString(@"Modified configuration file to remove path information", @"Window text")];
 		} else {
-            return [self logMessage: @"Unable to open configuration file for modification"
-                          localized: NSLocalizedString(@"Unable to open configuration file for modification", @"Window text")];
+            return [self logMessage: @"Unable to write to configuration file for modification"
+                          localized: NSLocalizedString(@"Unable to write to configuration file for modification", @"Window text")];
 		}
 	} else {
 		[self logMessage: @"Did not need to modify configuration file; no path information to remove"

--- a/tunnelblick/ConfigurationConverter.m
+++ b/tunnelblick/ConfigurationConverter.m
@@ -1441,7 +1441,24 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSString *, nameForErrorMessages)
             return [self logMessage: @"Unable to parse configuration file as UTF-8 (#2)"
                           localized: NSLocalizedString(@"Unable to parse configuration file as UTF-8", @"Window text")];
         }
+        NSDictionary * existingAttributes = [gFileMgr tbFileAttributesAtPath: configPath traverseLink: NO];
         if (  [configString writeToFile: configPath atomically: YES encoding: NSUTF8StringEncoding error: NULL]  ) {
+            id owner = [existingAttributes objectForKey: NSFileOwnerAccountID];
+            id group = [existingAttributes objectForKey: NSFileGroupOwnerAccountID];
+            id perms = [existingAttributes objectForKey: NSFilePosixPermissions];
+            if (   owner
+                && group
+                && perms  ) {
+                NSDictionary * restoreAttributes = [NSDictionary dictionaryWithObjectsAndKeys:
+                                                    owner, NSFileOwnerAccountID,
+                                                    group, NSFileGroupOwnerAccountID,
+                                                    perms, NSFilePosixPermissions,
+                                                    nil];
+                if (  ! [gFileMgr tbChangeFileAttributes: restoreAttributes atPath: configPath]  ) {
+                    return [self logMessage: @"Unable to restore permissions on configuration file after modification"
+                                  localized: NSLocalizedString(@"Unable to restore permissions on configuration file after modification", @"Window text")];
+                }
+            }
 			[self logMessage: @"Modified configuration file to remove path information"
                    localized: NSLocalizedString(@"Modified configuration file to remove path information", @"Window text")];
 		} else {

--- a/tunnelblick/KeyChain.m
+++ b/tunnelblick/KeyChain.m
@@ -37,8 +37,12 @@
 -(void) logStatus: (OSStatus) status message: (NSString *) message {
 	
 	CFStringRef cfS = SecCopyErrorMessageString(status, NULL);
-	NSString * statusString = [[(__bridge NSString *)cfS copy] autorelease];
-	CFRelease(cfS);
+	NSString * statusString = (  cfS
+							   ? [[(__bridge NSString *)cfS copy] autorelease]
+							   : @"(no error string)");
+	if (  cfS  ) {
+		CFRelease(cfS);
+	}
 	
 	appendLog([NSString stringWithFormat: @"%@: service = '%@'; account = '%@'; status was %d: '%@'",
 			   message, serviceName, accountName, status, statusString]);


### PR DESCRIPTION
Avoid a Keychain logging crash and do not truncate a live config before a successful write.

## Problem

1. `KeyChain` `logStatus:` always `CFRelease`s `SecCopyErrorMessageString`. That API may return NULL. `CFRelease(NULL)` is documented to crash. The method runs on retrieve, add, and delete failures.
2. Path-stripping in `ConfigurationConverter` opened the live `.ovpn` with `fopen(..., "w")`, which truncates immediately. A failed `fwrite` left an empty file.

## Change

- Release the error string only when it is non-NULL.
- Write the modified config with `writeToFile:atomically:YES`, matching the other copy paths in the same file.

## Validation

- Apple documents `SecCopyErrorMessageString` as returning NULL when no string is available.
- `writeToFile:atomically:YES` is already used at ConfigurationConverter.m:566 and :575.
- No unit-test harness for these GUI paths (same as #904).

## Related

- Sibling robustness: https://github.com/Tunnelblick/Tunnelblick/pull/904
