### PR TITLE
fix: bound helper and tunnelblickd NSTask waits

### DIFF
--- a/tunnelblick/tunnelblick-helper.m
+++ b/tunnelblick/tunnelblick-helper.m
@@ -1074,7 +1074,24 @@ static int runAsRootWithConfigNameAndLocCodeAndmanagementPasswordReturnOutput(NS
     becomeRoot([NSString stringWithFormat: @"launch %@", [thePath lastPathComponent]]);
 
         [task launch];
-        [task waitUntilExit];
+        // Same 60-second deadline as startTool in sharedRoutines.m
+        NSDate * startTime     = [NSDate date];
+        NSDate * warnTime      = [startTime dateByAddingTimeInterval: 10.0];
+        NSDate * terminateTime = [startTime dateByAddingTimeInterval: 60.0];
+        while (  [task isRunning]  ) {
+            usleep(ONE_TENTH_OF_A_SECOND_IN_MICROSECONDS);
+            if (  [warnTime compare: [NSDate date]] == NSOrderedAscending  ) {
+                warnTime = [warnTime dateByAddingTimeInterval: 10.0];
+                Log(@"Warning: program has not finished after %.0f seconds: %@",
+                    ([[NSDate date] timeIntervalSinceDate: startTime]), thePath);
+            }
+            if (   terminateTime
+                && ([terminateTime compare: [NSDate date]] == NSOrderedAscending)  ) {
+                Log(@"No response after 60 seconds; attempting to terminate program: %@", thePath);
+                [task terminate];
+                terminateTime = nil;
+            }
+        }
 
     stopBeingRoot();
 

--- a/tunnelblick/tunnelblickd.m
+++ b/tunnelblick/tunnelblickd.m
@@ -283,7 +283,27 @@ static OSStatus runTool(uid_t      client_euid,
     }
         [task launch];
 
-        [task waitUntilExit];
+        // Same style of deadline as startTool in sharedRoutines.m (warn, then SIGTERM).
+        // Helper commands include app updates, so allow longer than startTool's 60 seconds.
+        NSDate * startTime     = [NSDate date];
+        NSDate * warnTime      = [startTime dateByAddingTimeInterval: 30.0];
+        NSDate * terminateTime = [startTime dateByAddingTimeInterval: 300.0];
+        while (  [task isRunning]  ) {
+            usleep(ONE_TENTH_OF_A_SECOND_IN_MICROSECONDS);
+            if (  [warnTime compare: [NSDate date]] == NSOrderedAscending  ) {
+                warnTime = [warnTime dateByAddingTimeInterval: 30.0];
+                asl_log(asl, log_msg, ASL_LEVEL_NOTICE,
+                        "Warning: tunnelblick-helper has not finished after %.0f seconds",
+                        [[NSDate date] timeIntervalSinceDate: startTime]);
+            }
+            if (   terminateTime
+                && ([terminateTime compare: [NSDate date]] == NSOrderedAscending)  ) {
+                asl_log(asl, log_msg, ASL_LEVEL_ERR,
+                        "No response after 300 seconds; attempting to terminate tunnelblick-helper");
+                [task terminate];
+                terminateTime = nil;
+            }
+        }
 
         OSStatus status = [task terminationStatus];
 


### PR DESCRIPTION
Give helper and tunnelblickd NSTask waits a deadline.

## Problem

`tunnelblickd` is a single-threaded accept loop. It waits with `[task waitUntilExit]` for every helper command. The helper `runAsRoot` path does the same for scripts, `kextunload`, `killall`, and `codesign`. A hung child freezes all further VPN IPC until the process is killed.

## Change

Use the existing `startTool` pattern in `sharedRoutines.m` (warn, then SIGTERM):

- Helper children: warn every 10s, terminate after 60s (same as `startTool`).
- Daemon waiting on the helper: warn every 30s, terminate after 300s (helper commands include app updates).

`becomeRoot` still runs after the wait, so the daemon restores root even if the helper is terminated.

## Validation

- Copied the wait loop from `startTool` (`sharedRoutines.m` 1386-1411).
- Confirmed `startVPN` returns after launching OpenVPN, so the 60s helper-child limit is for short tools, not the VPN session.
- No daemon unit-test harness (same as #904).

## Related

- Sibling robustness: https://github.com/Tunnelblick/Tunnelblick/pull/904
