### PR TITLE
fix: escape easy-rsa path before embedding it in AppleScript

### DIFF
--- a/tunnelblick/easyRsa.m
+++ b/tunnelblick/easyRsa.m
@@ -427,6 +427,17 @@ BOOL secureOurEasyRsa(void) {
     return YES;
 }
 
+static NSString * appleScriptEscapedString(NSString * s) {
+
+    // Escape for a double-quoted AppleScript string.
+    NSMutableString * escaped = [[s mutableCopy] autorelease];
+    [escaped replaceOccurrencesOfString: @"\\" withString: @"\\\\" options: 0 range: NSMakeRange(0, [escaped length])];
+    [escaped replaceOccurrencesOfString: @"\"" withString: @"\\\"" options: 0 range: NSMakeRange(0, [escaped length])];
+    [escaped replaceOccurrencesOfString: @"\r" withString: @"\\r"   options: 0 range: NSMakeRange(0, [escaped length])];
+    [escaped replaceOccurrencesOfString: @"\n" withString: @"\\n"   options: 0 range: NSMakeRange(0, [escaped length])];
+    return escaped;
+}
+
 BOOL openTerminalWithEasyRsaFolder(NSString * userPath) {
 	
     if ( ! secureOurEasyRsa()  ) {
@@ -434,11 +445,13 @@ BOOL openTerminalWithEasyRsaFolder(NSString * userPath) {
         return NO;
     }
     
-	// Run an AppleScript to open Terminal.app and cd to the easy-rsa folder
+	// Run an AppleScript to open Terminal.app and cd to the easy-rsa folder.
+	// quoted form of builds a safe POSIX shell token for cd.
 	
 	NSArray * applescriptProgram = [NSArray arrayWithObjects:
                                     
-									[NSString stringWithFormat: @"set cmd to \"cd \\\"%@\\\"\"", userPath],
+									[NSString stringWithFormat: @"set thePath to \"%@\"", appleScriptEscapedString(userPath)],
+									@"set cmd to \"cd \" & quoted form of thePath",
 									@"tell application \"System Events\" to set terminalIsRunning to exists application process \"Terminal\"",
 									@"tell application \"Terminal\"",
 									@"     activate",


### PR DESCRIPTION
Escape the easy-rsa folder path before embedding it in AppleScript.

## Problem

`openTerminalWithEasyRsaFolder` built `set cmd to "cd \"PATH\""` with no escaping. A path containing `"` or `\` could break out of that AppleScript string when the user clicks Utilities to open easy-rsa in Terminal.

The path comes from the `easy-rsaPath` preference or the default Application Support folder. This is hygiene for a user-controlled path, not a privilege-boundary issue.

## Change

- Escape `\`, `"`, CR, and LF for a double-quoted AppleScript string.
- Set `thePath` to that string and build `cd` with AppleScript `quoted form of`, so Terminal gets one shell token.

## Validation

- Backslash is escaped first so later quote escaping stays intact.
- `quoted form of` is the usual AppleScript way to produce a POSIX-safe token.
- No GUI unit-test harness (same as #904).

## Related

- Sibling robustness: https://github.com/Tunnelblick/Tunnelblick/pull/904
