### PR TITLE
fix: add missing comma in program-preference allowlist

### DIFF
--- a/tunnelblick/defines.h
+++ b/tunnelblick/defines.h
@@ -1057,7 +1057,7 @@ name = newValue;                                    \
 @"updateCheckInterval",	\
 @"updateFeedURL",	\
 \
-@"NSStatusItem Preferred Position Item-0" \
+@"NSStatusItem Preferred Position Item-0",	\
 @"NSWindow Frame SettingsSheetWindow",	\
 @"NSWindow Frame ConnectingWindow",	\
 @"NSWindow Frame SUStatusFrame",	\


### PR DESCRIPTION
The program-preference allowlist is missing a comma after `NSStatusItem Preferred Position Item-0`, so that key and `NSWindow Frame SettingsSheetWindow` become one C string.

## Problem

Adjacent Objective-C string literals concatenate. In `NON_CONFIGURATIONS_PREFERENCES_NSARRAY`:

```
@"NSStatusItem Preferred Position Item-0" \
@"NSWindow Frame SettingsSheetWindow",
```

that is one entry: `NSStatusItem Preferred Position Item-0NSWindow Frame SettingsSheetWindow`.

`scanForUnknownPreferencesInDictionary` then warns that both real keys are unknown. It does not delete them.

The status-item hide/show bug in #906 is separate and already fixed by not hiding the item. This comma was omitted when the key was added in [`1b29a9c0ea`](https://github.com/Tunnelblick/Tunnelblick/commit/1b29a9c0ea566dd671a5c5cdab5d99ad953157a9) (2026-07-08).

## Change

Add the missing comma so both keys are separate allowlist entries.

## Validation

A small C program confirms adjacent literals concatenate (`concat_len=72`, the two names meet at `0N`) and that a two-element array keeps them separate. This repo has no first-party unit harness.

Ref #906
