### PR TITLE
fix: use dest display name in keychain preference keys

### DIFF
--- a/tunnelblick/helper.m
+++ b/tunnelblick/helper.m
@@ -1464,7 +1464,7 @@ BOOL copyOrMoveCredentials(NSString * fromDisplayName, NSString * toDisplayName,
         }
 
         if (   myPassphrase
-            && [gTbDefaults canChangeValueForKey: [toDisplayName stringByAppendingString: @"%@-keychainHasPrivateKey"]]  ) {
+            && [gTbDefaults canChangeValueForKey: [toDisplayName stringByAppendingString: @"-keychainHasPrivateKey"]]  ) {
             KeyChain * passphraseKeychain = [[KeyChain alloc] initWithService:[@"Tunnelblick-Auth-" stringByAppendingString: toDisplayName] withAccountName: @"privateKey" ];
             [passphraseKeychain deletePassword];
             if (  [passphraseKeychain setPassword: myPassphrase] != 0  ) {
@@ -1474,8 +1474,8 @@ BOOL copyOrMoveCredentials(NSString * fromDisplayName, NSString * toDisplayName,
         }
 
         if (   myUsername
-            && (   [gTbDefaults canChangeValueForKey: [toDisplayName stringByAppendingString: @"%@-keychainHasUsername"]]
-                || [gTbDefaults canChangeValueForKey: [toDisplayName stringByAppendingString: @"%@-keychainHasUsernameAndPassword"]]
+            && (   [gTbDefaults canChangeValueForKey: [toDisplayName stringByAppendingString: @"-keychainHasUsername"]]
+                || [gTbDefaults canChangeValueForKey: [toDisplayName stringByAppendingString: @"-keychainHasUsernameAndPassword"]]
                 )  ) {
             KeyChain * usernameKeychain   = [[KeyChain alloc] initWithService:[@"Tunnelblick-Auth-" stringByAppendingString: toDisplayName] withAccountName: @"username"   ];
             [usernameKeychain deletePassword];
@@ -1486,7 +1486,7 @@ BOOL copyOrMoveCredentials(NSString * fromDisplayName, NSString * toDisplayName,
         }
 
         if (   myPassword
-           && [gTbDefaults canChangeValueForKey: [toDisplayName stringByAppendingString: @"%@-keychainHasUsernameAndPassword"]]  ) {
+           && [gTbDefaults canChangeValueForKey: [toDisplayName stringByAppendingString: @"-keychainHasUsernameAndPassword"]]  ) {
             KeyChain * passwordKeychain   = [[KeyChain alloc] initWithService:[@"Tunnelblick-Auth-" stringByAppendingString: toDisplayName] withAccountName: @"password"   ];
             [passwordKeychain deletePassword];
             if (  [passwordKeychain setPassword: myPassword] != 0  ) {


### PR DESCRIPTION
When copying, renaming, or duplicating a configuration, dest Keychain preference checks used a literal `%@` in the key name, so an exact forced dest pref never matched.

## Problem

`copyOrMoveCredentials` in `helper.m` decides whether dest Keychain items may be written with `canChangeValueForKey:`.

The 2016 rename/duplicate fix ([`7e67c5573`](https://github.com/Tunnelblick/Tunnelblick/commit/7e67c55732552df63905f3f1ea3aef5e14c73171)) built helpers that form source keys correctly:

```
[name stringByAppendingString: @"-keychainHasPrivateKey"]
```

The dest checks still used:

```
[toDisplayName stringByAppendingString: @"%@-keychainHasPrivateKey"]
```

`stringByAppendingString:` does not interpolate `%@`, so the looked-up key is `MyVPN%@-keychainHasPrivateKey`. An admin-forced dest pref `MyVPN-keychainHasPrivateKey` never matches and the write proceeds. Wildcard `*-keychainHasPrivateKey` still matches the mangled suffix.

Callers: `ConfigurationManager` `copyCredentials` / `moveCredentials` (GUI copy, rename, duplicate).

This has been present since 2016-03-24.

## Change

Use the same `@"-keychainHas…"` suffix as `keychainHasPrivateKeyForDisplayName` and its siblings.

## Validation

A host check shows `stringByAppendingString` of `@"%@-keychainHasPrivateKey"` produces `MyVPN%@-keychainHasPrivateKey`, while the sibling helper form produces `MyVPN-keychainHasPrivateKey`. This repo has no first-party unit harness.
