### PR TITLE
fix: start disconnect before waiting when a config is removed

### DIFF
--- a/tunnelblick/MenuController.m
+++ b/tunnelblick/MenuController.m
@@ -2804,12 +2804,14 @@ static pthread_mutex_t configModifyMutex = PTHREAD_MUTEX_INITIALIZER;
     if (   myConnection
         && ( ! [[myConnection state] isEqualTo: @"EXITING"] )  ) {
         [myConnection addToLog: @"Disconnecting; user asked to delete the configuration"];
-        [myConnection performSelectorOnMainThread: @selector(startDisconnectingUserKnows:) withObject: @YES waitUntilDone: NO];
-        [myConnection waitUntilDisconnected];
+        [myConnection performSelectorOnMainThread: @selector(startDisconnectingUserKnows:) withObject: @YES waitUntilDone: YES];
+        BOOL gone = [myConnection waitUntilDisconnected];
 
-        NSString * localName = [myConnection localizedName];
-        TBShowAlertWindow([NSString stringWithFormat: NSLocalizedString(@"'%@' has been disconnected", @"Window title"), localName],
-                          [NSString stringWithFormat: NSLocalizedString(@"Tunnelblick has disconnected '%@' because its configuration file has been removed.", @"Window text"), localName]);
+        if (  gone  ) {
+            NSString * localName = [myConnection localizedName];
+            TBShowAlertWindow([NSString stringWithFormat: NSLocalizedString(@"'%@' has been disconnected", @"Window title"), localName],
+                              [NSString stringWithFormat: NSLocalizedString(@"Tunnelblick has disconnected '%@' because its configuration file has been removed.", @"Window text"), localName]);
+        }
     }
 
     OSStatus status = pthread_mutex_lock( &configModifyMutex );

--- a/tunnelblick/VPNConnection.m
+++ b/tunnelblick/VPNConnection.m
@@ -3376,6 +3376,9 @@ static pthread_mutex_t areDisconnectingMutex = PTHREAD_MUTEX_INITIALIZER;
     BOOL disconnectionComplete = FALSE;
     if (  pid > 0  ) {
         disconnectionComplete = [NSApp waitUntilNoProcessWithID: pid];
+    } else {
+        // No OpenVPN process (not started, or waiting for network). Nothing to wait for.
+        return YES;
     }
 
     if (  disconnectionComplete  ) {
@@ -3388,7 +3391,16 @@ static pthread_mutex_t areDisconnectingMutex = PTHREAD_MUTEX_INITIALIZER;
         }
     }
 
+    NSDate * terminateTime = [NSDate dateWithTimeIntervalSinceNow: 60.0];
+
     while (  ! disconnectionComplete  ) {
+        if (  [self isDisconnected]  ) {
+            return YES;
+        }
+        if (  [terminateTime compare: [NSDate date]] == NSOrderedAscending  ) {
+            NSLog(@"waitUntilDisconnected: timeout waiting for '%@' (pid = %ld)", [self displayName], (long) pid);
+            return NO;
+        }
         disconnectionComplete = FALSE;
         if (  pid > 0  ) {
             disconnectionComplete = [NSApp waitUntilNoProcessWithID: pid];


### PR DESCRIPTION
Deleting or replacing a connected configuration queued the disconnect on the main thread and then waited on that same thread, so OpenVPN was never signaled and the UI never returned.

## Problem

`configurationsChanged` always runs on the main thread (`performSelectorOnMainThread`). `deleteExistingConfig` then did:

```
[myConnection performSelectorOnMainThread:@selector(startDisconnectingUserKnows:)
                               withObject:@YES
                            waitUntilDone:NO];
[myConnection waitUntilDisconnected];
```

`waitUntilDone:NO` queues the kill behind the current main-thread call. `waitUntilDisconnected` blocks that call until the OpenVPN pid is gone. The process is never killed, `waitUntilNoProcessWithID` times out every 5 seconds, and the outer loop never ends.

If `pid == 0` (still connecting, or waiting for network), the same loop never ends because the wait is skipped and `disconnectionComplete` stays false.

Public path: delete or move a connected `.tblk` while Tunnelblick is running.

This wait has been unbounded since at least 2014 ([`60865ae5f`](https://github.com/Tunnelblick/Tunnelblick/commit/60865ae5f)). Same class as #910.

## Change

- Run `startDisconnectingUserKnows:` with `waitUntilDone:YES` so the kill happens before the wait (on the main thread Apple invokes the selector immediately).
- If there is no OpenVPN pid, return immediately.
- Bound the remaining wait to 60 seconds and return `NO` on timeout.
- Show the "has been disconnected" alert only when the wait succeeds.

## Validation

Control-flow check: with `waitUntilDone:NO` on the main thread, `startDisconnectingUserKnows:` cannot run until `deleteExistingConfig` returns, which it never does. This repo has no first-party unit harness.

Ref #910
