### PR TITLE
fix: copy non-UTF-8 config files as binary

### DIFF
--- a/tunnelblick/ConfigurationConverter.m
+++ b/tunnelblick/ConfigurationConverter.m
@@ -556,12 +556,7 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSString *, nameForErrorMessages)
 		}
 		
 		NSMutableString * contents = [[[NSMutableString alloc] initWithData: data encoding: NSUTF8StringEncoding] autorelease];
-		if (  contents == nil  ) {
-			[self logMessage: [NSString stringWithFormat: @"Unable to load contents of %@ as UTF-8", source]
-                   localized: [NSString stringWithFormat: NSLocalizedString(@"Unable to load contents of %@ as UTF-8", @"Window text"), source]];
-            return nil;
-        } else {
-		
+		if (  contents  ) {
             if (  [self removeOrReplaceCRs: contents]  ) {
                 if (  [contents writeToFile: target atomically: YES encoding: NSUTF8StringEncoding error: NULL]  ) {
                     [self logMessage: [NSString stringWithFormat: @"Copied %@, removing CR characters", [target lastPathComponent]]
@@ -582,15 +577,16 @@ TBSYNTHESIZE_OBJECT_GET(retain, NSString *, nameForErrorMessages)
                 }
             }
         }
+		[self logMessage: [NSString stringWithFormat: @"Unable to load contents of %@ as UTF-8", source]
+               localized: [NSString stringWithFormat: NSLocalizedString(@"Unable to load contents of %@ as UTF-8", @"Window text"), source]];
+	}
+	if (  [gFileMgr tbCopyPath: source toPath: target handler: nil]  ) {
+		[self logMessage: [NSString stringWithFormat: @"Copied %@", [target lastPathComponent]]
+			   localized: [NSString stringWithFormat: NSLocalizedString(@"Copied %@", @"Window text"), [target lastPathComponent]]];
+		return nil;
 	} else {
-		if (  [gFileMgr tbCopyPath: source toPath: target handler: nil]  ) {
-			[self logMessage: [NSString stringWithFormat: @"Copied %@", [target lastPathComponent]]
-				   localized: [NSString stringWithFormat: NSLocalizedString(@"Copied %@", @"Window text"), [target lastPathComponent]]];
-			return nil;
-		} else {
-			return [self logMessage: [NSString stringWithFormat: @"Failed to copy %@ to %@", source, target]
-						  localized: [NSString stringWithFormat: NSLocalizedString(@"Failed to copy %@ to %@", @"Window text"), source, target]];
-		}
+		return [self logMessage: [NSString stringWithFormat: @"Failed to copy %@ to %@", source, target]
+					  localized: [NSString stringWithFormat: NSLocalizedString(@"Failed to copy %@ to %@", @"Window text"), source, target]];
 	}
 	
 	return nil;


### PR DESCRIPTION
A non-UTF-8 `.sh` / `.key` / `.pem` / `.crt` / `.crl` was logged as a UTF-8 failure and then treated as a successful copy, so the dest file was never written.

## Problem

`duplicateFileFrom:toPath:` returns nil for success. After #726 ([`0f139357b`](https://github.com/Tunnelblick/Tunnelblick/commit/0f139357b4afb985e1c73912ac5133bb0eb4b7fd)), a UTF-8 decode failure logged the error and `return nil` without writing the dest file. Callers treated that as success and then `checkSetPermissions` ran on a missing dest (`#814`).

The #726 intent was to accept a binary `up` executable (for example `/bin/sh`). That needs a binary copy, not a silent skip.

## Change

On UTF-8 decode failure, keep the existing log line and fall through to the existing `tbCopyPath` branch. Valid UTF-8 files still get CR conversion as before.

## Validation

The success contract is `return nil`. The old UTF-8-failure path returned nil without creating `target`. The new path always calls `tbCopyPath` when decode fails. This repo has no first-party unit harness.

Ref #726
Ref #814
