### PR TITLE
fix: bound waitUntilCompletelyDisconnected and start disconnect first

### DIFF
--- a/tunnelblick/ConfigurationManager.m
+++ b/tunnelblick/ConfigurationManager.m
@@ -2344,7 +2344,7 @@ in: (NSString *) sharedOrPrivate {
         if (  connection  ) {
             if (  ! [[connection state] isEqualToString: @"EXITING"]  ) {
                 NSLog(@"Starting disconnection of '%@'", [connection displayName]);
-                [connection performSelectorOnMainThread: @selector(startDisconnectingUserKnows:) withObject: @YES waitUntilDone: NO];
+                [connection performSelectorOnMainThread: @selector(startDisconnectingUserKnows:) withObject: @YES waitUntilDone: YES];
             }
         } else {
             NSLog(@"No entry for '%@' in myVPNConnectionDictionary = '%@'", [connection displayName], dict);

--- a/tunnelblick/VPNConnection.m
+++ b/tunnelblick/VPNConnection.m
@@ -3593,14 +3593,19 @@ static pthread_mutex_t lastStateMutex = PTHREAD_MUTEX_INITIALIZER;
 
 -(void) waitUntilCompletelyDisconnected {
 
-    // Cannot be called on the main thread because it will never return
-    if (  [NSThread isMainThread]  ) {
-        NSLog(@"waitUntilCompletelyDisconnected: on main thread");
-        [gMC terminateBecause: terminatingBecauseOfError];
-    }
+    // 60s cap; on the main thread run the loop so socket callbacks can finish
+    NSDate * terminateTime = [NSDate dateWithTimeIntervalSinceNow: 60.0];
 
     while (  ! completelyDisconnected  ) {
-        usleep(ONE_TENTH_OF_A_SECOND_IN_MICROSECONDS);
+        if (  [terminateTime compare: [NSDate date]] == NSOrderedAscending  ) {
+            NSLog(@"waitUntilCompletelyDisconnected: timeout waiting for '%@'", [self displayName]);
+            return;
+        }
+        if (  [NSThread isMainThread]  ) {
+            [[NSRunLoop currentRunLoop] runUntilDate: [NSDate dateWithTimeIntervalSinceNow: 0.1]];
+        } else {
+            usleep(ONE_TENTH_OF_A_SECOND_IN_MICROSECONDS);
+        }
     }
 }
 


### PR DESCRIPTION
Install or replace of a connected configuration could hang the operation queue, or quit Tunnelblick if the install ran on the main thread.

## Problem

`ConfigurationManager` `disconnect:` (used when installing, replacing, or uninstalling a connected `.tblk`) did:

```
[connection performSelectorOnMainThread:@selector(startDisconnectingUserKnows:)
                               withObject:@YES
                            waitUntilDone:NO];
[connection waitUntilCompletelyDisconnected];
```

`waitUntilCompletelyDisconnected` spins on `completelyDisconnected` with no deadline. On a worker thread that hangs the install queue if the GUI flag never flips (`connectAfterDisconnect` reconnects without setting it). On the main thread (`runInstaller` installing bundled tblks) the waiter logged and called `terminateBecause`, quitting the app.

The same `waitUntilDone:NO` plus wait-on-this-thread pattern was the delete-config hang fixed in #914.

Public path: replace or uninstall a connected configuration. Also: upgrade or repair from a DMG that ships a same-name `.tblk` while a VPN is up.

The unbounded wait has been there since [`e6764837e`](https://github.com/Tunnelblick/Tunnelblick/commit/e6764837e) (2015-11-18).

## Change

- Start `startDisconnectingUserKnows:` with `waitUntilDone:YES`, same as `deleteExistingConfig` after #914.
- Cap `waitUntilCompletelyDisconnected` at 60 seconds and return on timeout.
- On the main thread, run the run loop in 0.1s slices so management-socket callbacks can set the flag. Do not quit the app.

## Validation

Control-flow: with `waitUntilDone:NO` on the main thread, `startDisconnectingUserKnows:` cannot run until `disconnect:` returns. The old waiter then called `terminateBecause`. This repo has no first-party unit harness.

Ref #914
Ref #910
