### PR TITLE
fix: rewrite forced preferences without deleting first

### DIFF
--- a/tunnelblick/installer.m
+++ b/tunnelblick/installer.m
@@ -2722,12 +2722,24 @@ static void mergeForcedPreferences(NSString * sourcePath) {
 		}
 		
 		if (  modifiedExistingPreferences  ) {
-            securelyDeleteItemIfItExists(targetPath);
+			if (  [gFileMgr fileExistsAtPath: targetPath]  ) {
+				errorExitIfAnySymlinkInPath(targetPath);
+				makeUnlockedAtPath(targetPath);
+			} else {
+				errorExitIfAnySymlinkInPath([targetPath stringByDeletingLastPathComponent]);
+			}
 			if (  ! [existingPreferences writeToFile: targetPath atomically: YES]  ) {
-				Log(@"Error: could not write %@  ", sourcePath);
+				Log(@"Error: could not write %@", targetPath);
 				errorExit();
 			}
-			
+			if (  ! checkSetOwnership(targetPath, NO, 0, 0)  ) {
+				Log(@"Unable to set ownership to root:wheel on %@", targetPath);
+				errorExit();
+			}
+			if (  ! checkSetPermissions(targetPath, PERMS_SECURED_READABLE, YES)  ) {
+				Log(@"Unable to set permissions of %ld on %@", (long)PERMS_SECURED_READABLE, targetPath);
+				errorExit();
+			}
 		} else {
 			Log(@"Do not need to create or modify             %@  ", targetPath);
 		}


### PR DESCRIPTION
Importing a `.tblkSetup` deleted the live forced-preferences file before rewriting it, so a failed write left the machine with no forced preferences.

## Problem

`mergeForcedPreferences` (installer `importSetup`) did:

```
securelyDeleteItemIfItExists(targetPath);
[existingPreferences writeToFile:targetPath atomically:YES];
```

`targetPath` is `/Library/Application Support/Tunnelblick/forced-preferences.plist`. The delete was added in [`03496299b`](https://github.com/Tunnelblick/Tunnelblick/commit/03496299b) (2023-07-04). The 2018 write was in place; atomic replace kept the old file if the write failed. After the delete, a failed write (disk full, I/O error) removes every forced preference.

The copy-install path for the same file (`~2001-2018`) always restores `root:wheel` and `0644`. The merge path did not.

Public path: import a Tunnelblick setup (`.tblkSetup`) that changes forced preferences.

## Change

- Do not delete the existing file.
- Unlock it (or check the parent path on first create), then `writeToFile:atomically:YES`.
- Restore `0:0` and `PERMS_SECURED_READABLE` (0644), same as the copy-install path.
- Log the target path on write failure (the old message logged the source).

## Validation

If `writeToFile:atomically:YES` fails, the previous plist inode is still present. This repo has no first-party unit harness. Same restore sequence as the existing copy-install of `L_AS_T_PRIMARY_FORCED_PREFERENCES_PATH`.
