### PR TITLE
fix: log a timeout when the DMG installer wait hits 30s

### DIFF
--- a/tunnelblick/MenuController.m
+++ b/tunnelblick/MenuController.m
@@ -4503,7 +4503,7 @@ static void signal_handler(int signalNumber)
             NSLog(@"Waiting for Tunnelblick installer to terminate");
             sleep(1);
         }
-        if (  timeoutCount > 60  ) {
+        if (  timeoutCount > 30  ) {
             NSLog(@"Timed out waiting for Tunnelblick installer to terminate");
         } else if (  timeoutCount != 0  ) {
             NSLog(@"Done waiting for Tunnelblick installer to terminate");


### PR DESCRIPTION
After a 30-second wait for the disk-image installer, Tunnelblick logged success instead of a timeout.

## Problem

`applicationDidFinishLaunching` waits while processes with prefix `/Volumes/Tunnelblick/Tunnelblick` exist, then ejects the disk image:

```
if (++timeoutCount > 30) break;
...
if (timeoutCount > 60)
    log timeout
else if (timeoutCount != 0)
    log done
```

The loop cannot leave `timeoutCount` greater than 31, so `> 60` never runs. A real timeout is logged as "Done waiting", then `diskutil eject` still runs.

[`280a6f9b`](https://github.com/Tunnelblick/Tunnelblick/commit/280a6f9b) (2015-12-03) set the wait to 30 seconds on purpose ("Allow up to 30 seconds for the Tunnelblick volume to be ejected"). The log test was left at 60.

Public path: first launch of the `/Applications` copy while the DMG installer is still running.

## Change

Compare `timeoutCount > 30` for the timeout log, matching the loop.

## Validation

If the loop breaks at `timeoutCount == 31`, `timeoutCount > 60` is false and the success log runs. After this change `timeoutCount > 30` is true and the timeout log runs. A wait that ends after a few seconds still logs success. This repo has no first-party unit harness.
